### PR TITLE
argocd-config: v0.17.0

### DIFF
--- a/stable/argocd-config/Chart.yaml
+++ b/stable/argocd-config/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.16.0
+version: 0.17.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/stable/argocd-config/templates/_helpers.tpl
+++ b/stable/argocd-config/templates/_helpers.tpl
@@ -6,6 +6,17 @@ Expand the name of the chart.
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "argocd.destinations" -}}
+{{- if . -}}
+{{- range . }}
+- namespace: {{ .targetNamespace }}
+  server: {{ default "https://kubernetes.default.svc" .server }}
+{{- end -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}
+
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).

--- a/stable/argocd-config/templates/project.yaml
+++ b/stable/argocd-config/templates/project.yaml
@@ -1,3 +1,6 @@
+{{ $globalDestinations := include "argocd.destinations" .Values.global.destinations  }}
+{{ $localDestinations := include "argocd.destinations" .Values.applicationTargets  }}
+{{/*{{ $destinations := concat $globalDestinations $localDestinations | uniq }}*/}}
 {{- if .Values.project }}
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
@@ -7,22 +10,18 @@ metadata:
   labels:
 {{ include "argocd.labels" . | indent 4 }}
   annotations:
-    "helm.sh/hook": pre-install
+    helm.sh/hook: pre-install
+    argocd.argoproj.io/sync-wave: "-5"
 spec:
   sourceRepos:
-  - '*'
+    - {{ .Values.repoUrl }}
+  {{- if .Values.clusterResourceWhitelist }}
   clusterResourceWhitelist:
-  - group: '*'
-    kind: '*'
-  {{- if .Values.applicationTargets }}
-  destinations:
-  - namespace: openshift-operators
-    server: "https://kubernetes.default.svc"
-  - namespace: operators
-    server: "https://kubernetes.default.svc"
-  {{- range .Values.applicationTargets }}
-  - namespace: {{ .targetNamespace }}
-    server: {{ default "https://kubernetes.default.svc" .server }}
+    {{- .Values.clusterResourceWhitelist | toYaml | nindent 4 }}
   {{- end }}
+  {{- if or $globalDestinations $localDestinations }}
+  destinations:
+  {{- $globalDestinations | nindent 4 -}}
+  {{- $localDestinations | nindent 4 -}}
   {{- end }}
 {{- end }}

--- a/stable/argocd-config/values.yaml
+++ b/stable/argocd-config/values.yaml
@@ -1,14 +1,27 @@
-# The url of the gitops repo that contains the applications
+global:
+  ## List of destinations (server and namespace) that should be added to the project
+  ## to allow deployments. Will be provided in addition to those listed in the
+  ## application targets.
+  destinations: []
+  #  - server: https://kubernetes.default.svc
+  #    targetNamespace: test
+
+## The url of the gitops repo that contains the applications
 repoUrl: ""
 
-# The name of the project. If left empty then will use 'default'
+## The name of the project. If left empty then will use 'default'
 project: ""
 
-# Lists the target environments and the names of the applications that should be created. 
-# The helm chart will loop over each `applicationTarget` and create an application for 
-# each `applicationName` (i.e. if there are 2 application targets each having 3 application
-# names then 6 applications will be created)
-applicationTargets: {}
+## The cluster resources that should be whitelisted in the project
+clusterResourceWhitelist: []
+# - group: ""
+#   kind: ""
+
+## Lists the target environments and the names of the applications that should be created.
+## The helm chart will loop over each `applicationTarget` and create an application for
+## each `applicationName` (i.e. if there are 2 application targets each having 3 application
+## names then 6 applications will be created)
+applicationTargets: []
 # - targetRevision: ""
 #   targetNamespace: ""
 #   createNamespace: true
@@ -32,9 +45,9 @@ applicationTargets: {}
 #     type: kustomize
 #     path: app4/overlay
 
-# Flag indicating that roles should be created for the 
-# argocd-application-controller service account in the 
-# target namespaces. Not sure why this is necessary...
+## Flag indicating that roles should be created for the
+## argocd-application-controller service account in the
+## target namespaces. Not sure why this is necessary...
 controllerRbac: false
 
 clusterType: ""


### PR DESCRIPTION
- Adds repoUrl to project instead of using "*"
- Adds support for destinations (server and namespace) set in global values
- Adds argocd.argoproj.io/sync-wave annotation to project

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>