### PR TITLE
openshift-gitops: v0.1.0

### DIFF
--- a/stable/openshift-gitops/.helmignore
+++ b/stable/openshift-gitops/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/stable/openshift-gitops/Chart.yaml
+++ b/stable/openshift-gitops/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: argocd-operator
+description: A Helm chart to install ArgoCD via the operator
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: 0.1.0

--- a/stable/openshift-gitops/templates/_helpers.tpl
+++ b/stable/openshift-gitops/templates/_helpers.tpl
@@ -1,0 +1,98 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "operator.name" -}}
+{{ include "operator.catalog-name" . }}
+{{- end -}}
+
+{{- define "operator.argocd-name" -}}
+{{ "argocd-cluster" }}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "operator.labels" -}}
+helm.sh/chart: {{ include "operator.chart" . }}
+{{ include "operator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "operator.cluster-type" -}}
+{{ default .Values.global.clusterType .Values.clusterType }}
+{{- end -}}
+
+{{/*
+Default OLM Namespace
+*/}}
+{{- define "operator.default-olm-namespace" -}}
+{{ default "openshift-marketplace" .Values.global.olmNamespace }}
+{{- end -}}
+
+{{/*
+OLM Namespace
+*/}}
+{{- define "operator.olm-namespace" -}}
+{{ default (include "operator.default-olm-namespace" .) .Values.olmNamespace }}
+{{- end -}}
+
+{{/*
+Operator Namespace
+*/}}
+{{- define "operator.default-operator-namespace" -}}
+{{ default "openshift-operators" .Values.global.operatorNamespace }}
+{{- end -}}
+
+{{/*
+Operator Namespace
+*/}}
+{{- define "operator.operator-namespace" -}}
+{{- if .Values.namespaceScoped -}}
+{{ .Release.Namespace }}
+{{- else -}}
+{{ default (include "operator.default-operator-namespace" .) .Values.operatorNamespace }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Operator Source
+*/}}
+{{- define "operator.source" -}}
+{{ .Values.subscription.source }}
+{{- end -}}
+
+{{/*
+Operator channel
+*/}}
+{{- define "operator.channel" -}}
+{{ .Values.subscription.channel }}
+{{- end -}}
+
+{{/*
+Operator catalog name
+*/}}
+{{- define "operator.catalog-name" -}}
+{{ .Values.subscription.name }}
+{{- end -}}

--- a/stable/openshift-gitops/templates/group.yaml
+++ b/stable/openshift-gitops/templates/group.yaml
@@ -1,0 +1,7 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+  name: argocd-admins
+  labels:
+    {{- include "operator.labels" . | nindent 4 }}
+users: []

--- a/stable/openshift-gitops/templates/instance-config-map.yaml
+++ b/stable/openshift-gitops/templates/instance-config-map.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.createInstance -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-{{ include "operator.name" . }}
+  namespace: openshift-gitops
+  labels:
+    {{- include "operator.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install
+data:
+  instance.yaml: |
+    apiVersion: argoproj.io/v1alpha1
+    kind: ArgoCD
+    metadata:
+      name: {{ include "operator.argocd-name" . }}
+    spec:
+      dex:
+        openShiftOAuth: true
+      rbac:
+        defaultPolicy: 'role:readonly'
+        policy: |
+          g, argocd-admins, role:admin
+        scopes: '[groups]'
+      server:
+        route:
+          enabled: true
+  patch.yaml: |
+    spec:
+      dex:
+        openShiftOAuth: true
+      rbac:
+        defaultPolicy: 'role:readonly'
+        policy: |
+          g, argocd-admins, role:admin
+        scopes: '[groups]'
+      server:
+        route:
+          enabled: true
+  apply.sh: |
+    INSTANCE_NAME="$1"
+    CONFIG_FILE="$2"
+    PATCH_FILE="$3"
+
+    if oc get argocd $INSTANCE_NAME 1> /dev/null 2> /dev/null; then
+      oc patch argocd $INSTANCE_NAME --type merge -p "$(cat $PATCH_FILE)"
+    else
+      oc apply -f $CONFIG_FILE
+    fi
+{{- end -}}

--- a/stable/openshift-gitops/templates/instance-job.yaml
+++ b/stable/openshift-gitops/templates/instance-job.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.createInstance -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: openshift-gitops
+  name: job-{{ include "operator.name" . }}
+  labels:
+    {{- include "operator.labels" . | nindent 4 }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: job-{{ include "operator.name" . }}
+  namespace: openshift-gitops
+  labels:
+    {{- include "operator.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    metadata:
+      name: job-{{ include "operator.name" . }}
+      labels:
+        {{- include "operator.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: job-{{ include "operator.name" . }}
+      restartPolicy: Never
+      volumes:
+        - name: config-yaml
+          configMap:
+            name: config-{{ include "operator.name" . }}
+      containers:
+        - name: create-instance
+          image: "quay.io/ibmgaragecloud/cli-tools:v13"
+          volumeMounts:
+            - mountPath: /tmp/config
+              name: config-yaml
+          env:
+            - name: INSTANCE_NAME
+              value: {{ include "operator.argocd-name" . }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - cp /tmp/config/apply.sh /tmp/apply.sh;
+              chmod +x /tmp/apply.sh;
+              /tmp/apply.sh $INSTANCE_NAME /tmp/config/instance.yaml /tmp/config/patch.yaml
+{{- end -}}

--- a/stable/openshift-gitops/templates/rbac.yaml
+++ b/stable/openshift-gitops/templates/rbac.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.controllerRbac -}}
+{{- $releaseNamespace := "openshift-gitops" -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ printf "%s-argocd" $releaseNamespace }}
+  labels:
+    {{ include "operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - "*"
+  resources:
+  - "*"
+  verbs:
+  - "*"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ printf "%s-argocd" $releaseNamespace }}
+  labels:
+    {{ include "operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ printf "%s-argocd" $releaseNamespace }}
+subjects:
+- kind: ServiceAccount
+  name: argocd-application-controller
+  namespace: {{ $releaseNamespace }}
+- kind: ServiceAccount
+  name: argocd-server
+  namespace: {{ $releaseNamespace }}
+- kind: ServiceAccount
+  name: job-{{ include "operator.name" . }}
+  namespace: {{ $releaseNamespace }}
+---
+{{- end -}}

--- a/stable/openshift-gitops/templates/subscription.yaml
+++ b/stable/openshift-gitops/templates/subscription.yaml
@@ -1,0 +1,17 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: {{ include "operator.catalog-name" . }}
+  namespace: {{ include "operator.operator-namespace" . }}
+  labels:
+    {{- include "operator.labels" . | nindent 4 }}
+spec:
+  channel: {{ include "operator.channel" . }}
+  installPlanApproval: Automatic
+  name: {{ include "operator.catalog-name" . }}
+  source: {{ include "operator.source" . }}
+  sourceNamespace: {{ include "operator.olm-namespace" . }}
+  config:
+    env:
+      - name: DISABLE_DEX
+        value: "false"

--- a/stable/openshift-gitops/values.yaml
+++ b/stable/openshift-gitops/values.yaml
@@ -1,0 +1,23 @@
+# Default values for argocd-operator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+global:
+  ingressSubdomain: ""
+  tlsSecretName: ""
+  clusterType: ""
+  olmNamespace: ""
+  operatorNamespace: ""
+
+nameOverride: ""
+
+olmNamespace: ""
+operatorNamespace: ""
+
+createInstance: true
+
+controllerRbac: true
+
+subscription:
+  source: redhat-operators
+  channel: preview
+  name: openshift-gitops-operator


### PR DESCRIPTION
- Provides initial version of helm chart that installs subscription and instance (via a job)

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>