### PR TITLE
openshift-gitops: v0.4.0

### DIFF
--- a/stable/openshift-gitops/Chart.yaml
+++ b/stable/openshift-gitops/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.3.0
+appVersion: 0.4.0

--- a/stable/openshift-gitops/templates/instance-config-map.yaml
+++ b/stable/openshift-gitops/templates/instance-config-map.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-{{ include "operator.name" . }}
-  namespace: openshift-gitops
+  namespace: {{ include "operator.operator-namespace" . }}
   labels:
     {{- include "operator.labels" . | nindent 4 }}
   annotations:
@@ -38,13 +38,14 @@ data:
         route:
           enabled: true
   apply.sh: |
-    INSTANCE_NAME="$1"
-    CONFIG_FILE="$2"
-    PATCH_FILE="$3"
+    NAMESPACE="$1"
+    INSTANCE_NAME="$2"
+    CONFIG_FILE="$3"
+    PATCH_FILE="$4"
 
-    if oc get argocd $INSTANCE_NAME 1> /dev/null 2> /dev/null; then
-      kubectl patch argocd $INSTANCE_NAME --type merge -p "$(cat $PATCH_FILE)"
+    if oc get argocd $INSTANCE_NAME -n $NAMESPACE 1> /dev/null 2> /dev/null; then
+      kubectl patch argocd $INSTANCE_NAME -n $NAMESPACE --type merge -p "$(cat $PATCH_FILE)"
     else
-      kubectl apply -f $CONFIG_FILE
+      kubectl apply -n $NAMESPACE -f $CONFIG_FILE
     fi
 {{- end -}}

--- a/stable/openshift-gitops/templates/instance-job.yaml
+++ b/stable/openshift-gitops/templates/instance-job.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: openshift-gitops
+  namespace: {{ include "operator.operator-namespace" . }}
   name: job-{{ include "operator.name" . }}
   labels:
     {{- include "operator.labels" . | nindent 4 }}
@@ -11,7 +11,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: job-{{ include "operator.name" . }}
-  namespace: openshift-gitops
+  namespace: {{ include "operator.operator-namespace" . }}
   labels:
     {{- include "operator.labels" . | nindent 4 }}
   annotations:
@@ -37,11 +37,13 @@ spec:
             - mountPath: /tmp/config
               name: config-yaml
           env:
+            - name: NAMESPACE
+              value: openshift-gitops
             - name: INSTANCE_NAME
               value: {{ include "operator.argocd-name" . }}
           command: ["/bin/sh", "-c"]
           args:
             - cp /tmp/config/apply.sh /tmp/apply.sh;
               chmod +x /tmp/apply.sh;
-              /tmp/apply.sh $INSTANCE_NAME /tmp/config/instance.yaml /tmp/config/patch.yaml
+              /tmp/apply.sh $NAMESPACE $INSTANCE_NAME /tmp/config/instance.yaml /tmp/config/patch.yaml
 {{- end -}}

--- a/stable/openshift-gitops/templates/rbac.yaml
+++ b/stable/openshift-gitops/templates/rbac.yaml
@@ -33,6 +33,6 @@ subjects:
   namespace: {{ $releaseNamespace }}
 - kind: ServiceAccount
   name: job-{{ include "operator.name" . }}
-  namespace: {{ $releaseNamespace }}
+  namespace: {{ include "operator.operator-namespace" . }}
 ---
 {{- end -}}


### PR DESCRIPTION
- Generates job in openshift-operators namespace because openshift-gitops does not exist initially
- Configure serviceaccount for job with permission to work on resources in openshift-gitops namespace

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>