### PR TITLE
openshift-gitops: v0.6.0

### DIFF
--- a/stable/openshift-gitops/Chart.yaml
+++ b/stable/openshift-gitops/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.5.0
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/stable/openshift-gitops/values.yaml
+++ b/stable/openshift-gitops/values.yaml
@@ -24,5 +24,5 @@ controllerRbac: true
 
 subscription:
   source: redhat-operators
-  channel: preview
+  channel: stable
   name: openshift-gitops-operator


### PR DESCRIPTION
- Updates default channel to 'stable' for subscription

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>