### PR TITLE
console-link-cronjob: v0.1.0

### DIFF
--- a/stable/console-link-cronjob/.helmignore
+++ b/stable/console-link-cronjob/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/stable/console-link-cronjob/Chart.yaml
+++ b/stable/console-link-cronjob/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: console-link-cronjob
+description: A Helm chart to generate a cron job that watches Routes for annotations and generates ConsoleLinks if they are present
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: v0.1.0

--- a/stable/console-link-cronjob/templates/_helpers.tpl
+++ b/stable/console-link-cronjob/templates/_helpers.tpl
@@ -1,0 +1,66 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "console-link-cronjob.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "console-link-cronjob.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "console-link-cronjob.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "console-link-cronjob.labels" -}}
+helm.sh/chart: {{ include "console-link-cronjob.chart" . }}
+{{ include "console-link-cronjob.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "console-link-cronjob.imageTag" -}}
+{{ default .Chart.AppVersion .Values.imageTag }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "console-link-cronjob.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "console-link-cronjob.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "console-link-cronjob.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "console-link-cronjob.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/stable/console-link-cronjob/templates/configmap.yaml
+++ b/stable/console-link-cronjob/templates/configmap.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "console-link-cronjob.fullname" . }}
+  labels:
+  {{- include "console-link-cronjob.labels" . | nindent 4 }}
+data:
+  reconcile-console-links.sh: |
+    #!/bin/bash
+
+    DEFAULT_SECTION="Cloud-Native Toolkit"
+    DEFAULT_LOCATION="ApplicationMenu"
+
+    # list all routes with console-link.cloud-native-toolkit.dev/enabled annotation
+    ROUTES=$(kubectl get routes -A -l console-link.cloud-native-toolkit.dev/enabled=true -o yaml | yq eval -j '.' - | jq -c '.items[]')
+
+    if [[ -z "${ROUTES}" ]]; then
+      echo "No routes found with 'console-link.cloud-native-toolkit.dev/enabled=true' annotation"
+      exit 0
+    fi
+
+    # for each route create/update a console link
+    echo "${ROUTES}" | while read route; do
+      section=$(echo "${route}" | jq -r --arg DEFAULT "${DEFAULT_SECTION}" '.metadata.annotations["console-link.cloud-native-toolkit.dev/section"] // $DEFAULT')
+      location=$(echo "${route}" | jq -r --arg DEFAULT "${DEFAULT_LOCATION}" '.metadata.annotations["console-link.cloud-native-toolkit.dev/location"] // $DEFAULT')
+      imageURL=$(echo "${route}" | jq -r '.metadata.annotations["console-link.cloud-native-toolkit.dev/imageUrl"] // empty')
+      name=$(echo "${route}" | jq -r '.metadata.name')
+      text=$(echo "${route}" | jq -r --arg DEFAULT "$name" '.metadata.annotations["console-link.cloud-native-toolkit.dev/displayName"] // $DEFAULT')
+      host=$(echo "${route}" | jq -r '.spec.host')
+
+      cat > ./tmp.console-link.yaml << EOL
+    apiVersion: console.openshift.io/v1
+    kind: ConsoleLink
+    metadata:
+      name: $name
+    spec:
+      applicationMenu:
+        imageURL: "$imageURL"
+        section: "$section"
+      href: "https://$host"
+      location: "$location"
+      text: "$text"
+    EOL
+
+      echo "Creating/updating consolelink: ${name}"
+      kubectl apply -f ./tmp.console-link.yaml
+    done

--- a/stable/console-link-cronjob/templates/cronjob.yaml
+++ b/stable/console-link-cronjob/templates/cronjob.yaml
@@ -1,0 +1,27 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ include "console-link-cronjob.fullname" . }}
+  labels:
+  {{- include "console-link-cronjob.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.schedule | quote }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          volumes:
+            - name: scripts
+              configMap:
+                name: {{ include "console-link-cronjob.fullname" . }}
+                defaultMode: 0777
+          serviceAccountName: {{ include "console-link-cronjob.serviceAccountName" . }}
+          containers:
+            - name: job
+              image: {{ printf "%s:%s" .Values.image (include "console-link-cronjob.imageTag" .) | quote }}
+              volumeMounts:
+                - mountPath: /scripts
+                  name: scripts
+              command:
+                - /scripts/reconcile-console-links.sh

--- a/stable/console-link-cronjob/templates/rbac.yaml
+++ b/stable/console-link-cronjob/templates/rbac.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.rbac -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "console-link-cronjob.fullname" . }}
+  labels:
+  {{- include "console-link-cronjob.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["route.openshift.io"]
+    resources: ["routes"]
+    verbs: ["list", "get"]
+  - apiGroups: ["console.openshift.io"]
+    resources: ["consolelinks"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "console-link-cronjob.fullname" . }}
+  labels:
+  {{- include "console-link-cronjob.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "console-link-cronjob.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "console-link-cronjob.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/stable/console-link-cronjob/templates/serviceaccount.yaml
+++ b/stable/console-link-cronjob/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "console-link-cronjob.serviceAccountName" . }}
+  labels:
+    {{- include "console-link-cronjob.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/stable/console-link-cronjob/values.yaml
+++ b/stable/console-link-cronjob/values.yaml
@@ -1,0 +1,14 @@
+# Default values for console-link-cronjob.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+rbac: true
+
+schedule: "*/5 * * * *"
+
+serviceAccount:
+  create: true
+  name: ""
+
+image: quay.io/cloudnativetoolkit/console-link-cronjob
+imageTag: ""


### PR DESCRIPTION
- Adds chart to create a cronjob (and optionally the required serviceaccount and rbac

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>