### PR TITLE
console-link-cronjob: v0.1.1

### DIFF
--- a/stable/console-link-cronjob/Chart.yaml
+++ b/stable/console-link-cronjob/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/console-link-cronjob/templates/configmap.yaml
+++ b/stable/console-link-cronjob/templates/configmap.yaml
@@ -28,7 +28,7 @@ data:
       text=$(echo "${route}" | jq -r --arg DEFAULT "$name" '.metadata.annotations["console-link.cloud-native-toolkit.dev/displayName"] // $DEFAULT')
       host=$(echo "${route}" | jq -r '.spec.host')
 
-      cat > ./tmp.console-link.yaml << EOL
+      cat > /tmp/console-link.yaml << EOL
     apiVersion: console.openshift.io/v1
     kind: ConsoleLink
     metadata:
@@ -43,5 +43,5 @@ data:
     EOL
 
       echo "Creating/updating consolelink: ${name}"
-      kubectl apply -f ./tmp.console-link.yaml
+      kubectl apply -f /tmp/console-link.yaml
     done


### PR DESCRIPTION
- Writes temporary file into /tmp directory to prevent error writing to read-only directory

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>