### PR TITLE
console-link-cronjob: v0.4.0

### DIFF
--- a/stable/console-link-cronjob/.helmignore
+++ b/stable/console-link-cronjob/.helmignore
@@ -21,3 +21,5 @@
 .idea/
 *.tmproj
 .vscode/
+scripts/
+support/

--- a/stable/console-link-cronjob/Chart.yaml
+++ b/stable/console-link-cronjob/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/console-link-cronjob/README.md
+++ b/stable/console-link-cronjob/README.md
@@ -1,0 +1,97 @@
+# Console Link Cronjob chart
+
+This helm chart provisions a cronjob in a cluster that runs frequently (every 5 minutes by default) in search of resources that should be used to generate a ConsoleLink (and optionally a ConfigMap). Generally, there are two challenges associated with creating ConsoleLinks in a declarative manner: 1) permissions to create console-level resources and 2) the dynamic nature of some of the endpoints, particularly the url of the route. The cronjob created by this module scans the deployed resources and generates the resources accordingly.
+
+**Note:** This cronjob is a poor-man's admission controller or operator and may eventually be replaced to be a bit more efficient. If nothing else this logic shows that there is more than one way to implement logic in a cluster and that not everything needs to be an operator.
+
+## Use cases
+
+There are three different use cases addressed by the cronjob:
+
+1. Resources hosted inside the cluster - create a ConsoleLink and ConfigMap from a Route
+2. Resources hosted outside the cluster - create a ConsoleLink from a ConfigMap
+2. Resources attached to the cluster - create a ConsoleLink and ConfigMap when a Logdna or Sysdig agent are installed into the cluster
+
+Labels and annotations control the behavior of the cronjob and the resources that are created for the first two use cases. The LogDNA and Sysdig behavior is dictated by the existence of the daemonsets in the `ibm-observe` namespace and environment variables defined on the cronjob.
+
+## Labels and annotations
+
+A label marks the routes and config maps for which the console link should be created. Annotations provide the configuration values for the generated console link.
+
+**Note:** Labels in kubernetes are indexed in the etcd database and therefore provide a mechanism to optimize the search for resource in the cluster. A label has been used in this case to mark the resources so we are able to do an indexed search for the resources instead of what amounts to a table scan across all the namespaces.
+
+### Label
+
+The cronjob searches for all routes and config maps that have the label `console-link.cloud-native-toolkit.dev/enabled` with a value of `true`. To enable the generation of the console link for a particular resource, simply add or remove the label (or change the value to `false`).
+
+| Label                                    | Description                                                                | Value             |
+|-----------------------------------------------|----------------------------------------------------------------------------|-------------------|
+| console-link.cloud-native-toolkit.dev/enabled | Flag indicating that a console link should be generated from this resource | "true" or "false" |
+
+### Annotations
+
+The following annotations control the values that are provided for the generated console link. See https://docs.openshift.com/container-platform/4.7/rest_api/console_apis/consolelink-console-openshift-io-v1.html for an overview of the attributes of a console link.
+
+| Label | Description | Value |
+|-------|-------------|-------|
+| console-link.cloud-native-toolkit.dev/section     | The section heading where the console link should appear in the menu. If not provided the cronjob will look for an environment variable named DEFAULT_SECTION. If the environment variable is not set the value will default to "Cloud-Native Toolkit" | "Cloud-Native Toolkit" |
+| console-link.cloud-native-toolkit.dev/location    | The location of the console link item. If not provided the cronjob will look for an environment variable named DEFAULT_LOCATION. If the environment variable is not set the value will default to "ApplicationMenu" | ApplicationMenu, HelpMenu, UserMenu, or NamespaceDashboard |
+| console-link.cloud-native-toolkit.dev/imageUrl    | The url of the image that will appear in the menu. The value can either be an https url or a `data:` value. If not provided then no image will be used |   |
+| console-link.cloud-native-toolkit.dev/displayName | The display name that will appear in the menu. If not provided the value will default to the name in the resource |   |
+| console-link.cloud-native-toolkit.dev/category    | The category or grouping of the tool (e.g. artifact-management, static-analysis, security). Currently this value is not used in the console link |   |
+
+### Examples
+
+**Route**
+
+```yaml
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    console-link.cloud-native-toolkit.dev/enabled: "true"
+  annotations:
+    console-link.cloud-native-toolkit.dev/section: Cloud-Native Toolkit
+    console-link.cloud-native-toolkit.dev/location: ApplicationMenu
+    console-link.cloud-native-toolkit.dev/displayName: Pact Broker
+    console-link.cloud-native-toolkit.dev/imageUrl: data:image/png;base64,...
+  name: pact-broker
+spec:
+  host: pact-broker-tools.ocp47-test2-4be51d31de4db1e93b5ed298cdf6bb62-0000.us-south.containers.appdomain.cloud
+  port:
+    targetPort: http
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  to:
+    kind: Service
+    name: pact-broker
+    weight: 100
+  wildcardPolicy: None
+```
+
+**Config Map**
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    console-link.cloud-native-toolkit.dev/enabled: "true"
+  annotations:
+    console-link.cloud-native-toolkit.dev/section: Cloud-Native Toolkit
+    console-link.cloud-native-toolkit.dev/location: ApplicationMenu
+    console-link.cloud-native-toolkit.dev/displayName: IBM Container Registry
+    console-link.cloud-native-toolkit.dev/imageUrl: data:image/png;base64,...
+  name: registry-config
+data:
+  url: https://cloud.ibm.com/registry/namespaces?region=eu-central
+```
+
+## Development
+
+The shell scripts executed by the cronjob can be found in the scripts/ folder. Locating the scripts here makes it easier to test the logic. When the scripts have been tested and the logic is ready to be deployed, the scripts/_update-configmap.sh shell script can be used to update the script logic located in the config map template. The "header" of the config map template can be found in the support/ folder.
+
+When the job starts, the contents of the config map are mounted as a volume and the shell scripts are available as executables in the pod.
+
+Both the scripts/ and support/ folders have been added to .helmignore so the files don't get packaged with the helm chart.

--- a/stable/console-link-cronjob/scripts/_update-configmap.sh
+++ b/stable/console-link-cronjob/scripts/_update-configmap.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
+SUPPORT_DIR=$(cd "${SCRIPT_DIR}/../support"; pwd -P)
+TEMPLATE_DIR=$(cd "${SCRIPT_DIR}/../templates"; pwd -P)
+
+cat "${SUPPORT_DIR}/configmap.snippet.yaml" > "${TEMPLATE_DIR}/configmap.yaml"
+
+oc create configmap tmp \
+  --from-file=${SCRIPT_DIR}/reconcile-route-console-links.sh \
+  --from-file=${SCRIPT_DIR}/reconcile-ibm-observe-console-links.sh \
+  --dry-run=client \
+  -o yaml | \
+yq eval 'del(.apiVersion) | del(.kind) | del(.metadata)' - >> "${TEMPLATE_DIR}/configmap.yaml"

--- a/stable/console-link-cronjob/scripts/reconcile-ibm-observe-console-links.sh
+++ b/stable/console-link-cronjob/scripts/reconcile-ibm-observe-console-links.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+if [[ -z "${DEFAULT_SECTION}" ]]; then
+  DEFAULT_SECTION="Cloud-Native Toolkit"
+fi
+
+if [[ -z "${DEFAULT_LOCATION}" ]]; then
+  DEFAULT_LOCATION="ApplicationMenu"
+fi
+
+# list all routes with console-link.cloud-native-toolkit.dev/enabled annotation
+DAEMON_SETS=$(kubectl get daemonsets -n ibm-observe -o yaml | yq eval -j '.' - | jq -c '.items[] | del(.metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"])')
+
+AGENT_NAME=$(echo "${DAEMON_SETS}" | jq 'select(.metadata.name = "logdna-agent") | .metadata.name // empty')
+name="ibm-logging"
+imageURL="${LOGGING_IMAGE}"
+text="IBM Log Analysis"
+url="https://cloud.ibm.com/observe/logging"
+
+if [[ -n "${AGENT_NAME}" ]] && ! kubectl get consolelink "${name}" 1> /dev/null 2> /dev/null; then
+  cat > /tmp/console-link.yaml << EOL
+apiVersion: console.openshift.io/v1
+kind: ConsoleLink
+metadata:
+  name: $name
+spec:
+  applicationMenu:
+    imageURL: "$imageURL"
+    section: "$DEFAULT_SECTION"
+  href: "$url"
+  location: "$DEFAULT_LOCATION"
+  text: "$text"
+EOL
+
+  echo "Creating/updating consolelink: ${name}"
+  kubectl apply -f /tmp/console-link.yaml
+elif [[ -z "${AGENT_NAME}" ]]; then
+  # delete consolelink
+  kubectl delete consolelink "${name}"
+else
+  echo "Console link already exists: ${name}"
+fi
+
+AGENT_NAME=$(echo "${DAEMON_SETS}" | jq 'select(.metadata.name = "sysdig-agent") | .metadata.name // empty')
+name="ibm-monitoring"
+imageURL="${MONITORING_IMAGE}"
+text="IBM Monitoring"
+url="https://cloud.ibm.com/observe/monitoring"
+
+if [[ -n "${AGENT_NAME}" ]] && ! kubectl get consolelink "${name}" 1> /dev/null 2> /dev/null; then
+  cat > /tmp/console-link.yaml << EOL
+apiVersion: console.openshift.io/v1
+kind: ConsoleLink
+metadata:
+  name: $name
+spec:
+  applicationMenu:
+    imageURL: "$imageURL"
+    section: "$DEFAULT_SECTION"
+  href: "$url"
+  location: "$DEFAULT_LOCATION"
+  text: "$text"
+EOL
+
+  echo "Creating/updating consolelink: ${name}"
+  kubectl apply -f /tmp/console-link.yaml
+elif [[ -z "${AGENT_NAME}" ]]; then
+  # delete consolelink
+  kubectl delete consolelink "${name}"
+else
+  echo "Console link already exists: ${name}"
+fi

--- a/stable/console-link-cronjob/scripts/reconcile-route-console-links.sh
+++ b/stable/console-link-cronjob/scripts/reconcile-route-console-links.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+if [[ -z "${DEFAULT_SECTION}" ]]; then
+  DEFAULT_SECTION="Cloud-Native Toolkit"
+fi
+
+if [[ -z "${DEFAULT_LOCATION}" ]]; then
+  DEFAULT_LOCATION="ApplicationMenu"
+fi
+
+# list all routes and configmaps with console-link.cloud-native-toolkit.dev/enabled label
+RESOURCES=$(kubectl get routes,configmaps -A -l console-link.cloud-native-toolkit.dev/enabled=true -o yaml | yq eval -j '.' - | jq -c '.items[] | del(.metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"])')
+
+if [[ -z "${RESOURCES}" ]]; then
+  echo "No resources found with 'console-link.cloud-native-toolkit.dev/enabled=true' label"
+  exit 0
+fi
+
+# for each resource create/update a console link
+echo "${RESOURCES}" | while read -r resource; do
+  namespace="$(echo "${resource}" | jq -r '.metadata.namespace')"
+  name="$(echo "${resource}" | jq -r '.metadata.name')"
+  if [[ -z "${name}" ]]; then
+    echo "Error parsing resource: ${resource}"
+    continue
+  fi
+
+  kind="$(echo "${resource}" | jq -r '.kind')"
+
+  if [[ "${kind}" == "Route" ]]; then
+    host="$(echo "${resource}" | jq -r '.spec.host')"
+    url="https://${host}"
+  elif [[ "${kind}" == "ConfigMap" ]]; then
+    url="$(echo "${resource}" | jq -r '.data.url')"
+  else
+    echo "Unhandled resource: ${kind}"
+    continue
+  fi
+
+  category="$(echo "${resource}" | jq -r '.metadata.annotations["console-link.cloud-native-toolkit.dev/category"] // empty')"
+  section="$(echo "${resource}" | jq -r --arg DEFAULT "${DEFAULT_SECTION}" '.metadata.annotations["console-link.cloud-native-toolkit.dev/section"] // $DEFAULT')"
+  location="$(echo "${resource}" | jq -r --arg DEFAULT "${DEFAULT_LOCATION}" '.metadata.annotations["console-link.cloud-native-toolkit.dev/location"] // $DEFAULT')"
+  imageURL="$(echo "${resource}" | jq -r '.metadata.annotations["console-link.cloud-native-toolkit.dev/imageUrl"] // empty')"
+  text="$(echo "${resource}" | jq -r --arg DEFAULT "$name" '.metadata.annotations["console-link.cloud-native-toolkit.dev/displayName"] // $DEFAULT')"
+
+  app="$(echo "${resource}" | jq -r --arg DEFAULT "${name}" '.metadata.labels["app.kubernetes.io/name"] // $DEFAULT')"
+  if [[ -z "${app}" ]]; then
+    app="$(echo "${resource}" | jq -r --arg DEFAULT "${name}" '.metadata.labels["app"] // $DEFAULT')"
+  fi
+  partOf="$(echo "${resource}" | jq -r --arg DEFAULT "${name}" '.metadata.labels["app.kubernetes.io/part-of"] // $DEFAULT')"
+
+  cat > /tmp/console-link.yaml << EOL
+apiVersion: console.openshift.io/v1
+kind: ConsoleLink
+metadata:
+  name: $name
+spec:
+  applicationMenu:
+    imageURL: "$imageURL"
+    section: "$section"
+  href: "$url"
+  location: "$location"
+  text: "$text"
+EOL
+
+  echo "Creating/updating consolelink: ${name}"
+  kubectl apply -f /tmp/console-link.yaml
+
+  if [[ "${kind}" == "ConfigMap" ]]; then
+    echo "ConfigMap already exists. Skipping config map create"
+    continue
+  fi
+
+  prefix=$(echo ${name^^} | sed "s/-/_/g")
+
+  cat > /tmp/configmap.yaml << EOL
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ${name}-config
+  labels:
+    group: cloud-native-toolkit
+    app.kubernetes.io/component: tools
+    app.kubernetes.io/part-of: ${partOf}
+    app: ${app}
+    app.kubernetes.io/name: ${app}
+  annotations:
+    console-link.cloud-native-toolkit.dev/category: ${category}
+    console-link.cloud-native-toolkit.dev/section: ${section}
+    console-link.cloud-native-toolkit.dev/location: ${location}
+    console-link.cloud-native-toolkit.dev/imageUrl: ${imageUrl}
+    console-link.cloud-native-toolkit.dev/displayName: ${text}
+spec:
+  ${prefix}_URL: "$url"
+  url: "$url"
+EOL
+
+  echo "Creating/updating configmap: ${name}-config"
+  kubectl apply -n "${namespace}" -f /tmp/configmap.yaml
+done

--- a/stable/console-link-cronjob/support/configmap.snippet.yaml
+++ b/stable/console-link-cronjob/support/configmap.snippet.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "console-link-cronjob.fullname" . }}
+  labels:
+  {{- include "console-link-cronjob.labels" . | nindent 4 }}

--- a/stable/console-link-cronjob/templates/configmap.yaml
+++ b/stable/console-link-cronjob/templates/configmap.yaml
@@ -5,89 +5,16 @@ metadata:
   labels:
   {{- include "console-link-cronjob.labels" . | nindent 4 }}
 data:
-  reconcile-route-console-links.sh: |
-    #!/bin/bash
-
-    DEFAULT_SECTION="Cloud-Native Toolkit"
-    DEFAULT_LOCATION="ApplicationMenu"
-
-    # list all routes with console-link.cloud-native-toolkit.dev/enabled annotation
-    ROUTES=$(kubectl get routes -A -l console-link.cloud-native-toolkit.dev/enabled=true -o yaml | yq eval -j '.' - | jq -c '.items[] | del(.metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"])')
-
-    if [[ -z "${ROUTES}" ]]; then
-      echo "No routes found with 'console-link.cloud-native-toolkit.dev/enabled=true' annotation"
-      exit 0
-    fi
-
-    # for each route create/update a console link
-    echo "${ROUTES}" | while read -r route; do
-      namespace="$(echo "${route}" | jq -r '.metadata.namespace')"
-      name="$(echo "${route}" | jq -r '.metadata.name')"
-      if [[ -z "${name}" ]]; then
-        echo "Error parsing route: ${ROUTE}"
-        continue
-      fi
-      host="$(echo "${route}" | jq -r '.spec.host')"
-
-      category="$(echo "${route}" | jq -r '.metadata.annotations["console-link.cloud-native-toolkit.dev/category"] // empty')"
-      section="$(echo "${route}" | jq -r --arg DEFAULT "${DEFAULT_SECTION}" '.metadata.annotations["console-link.cloud-native-toolkit.dev/section"] // $DEFAULT')"
-      location="$(echo "${route}" | jq -r --arg DEFAULT "${DEFAULT_LOCATION}" '.metadata.annotations["console-link.cloud-native-toolkit.dev/location"] // $DEFAULT')"
-      imageURL="$(echo "${route}" | jq -r '.metadata.annotations["console-link.cloud-native-toolkit.dev/imageUrl"] // empty')"
-      text="$(echo "${route}" | jq -r --arg DEFAULT "$name" '.metadata.annotations["console-link.cloud-native-toolkit.dev/displayName"] // $DEFAULT')"
-
-      app="$(echo "${route}" | jq -r --arg DEFAULT "${name}" '.metadata.labels["app.kubernetes.io/name"] // $DEFAULT')"
-      if [[ -z "${app}" ]]; then
-        app="$(echo "${route}" | jq -r --arg DEFAULT "${name}" '.metadata.labels["app"] // $DEFAULT')"
-      fi
-      partOf="$(echo "${route}" | jq -r --arg DEFAULT "${name}" '.metadata.labels["app.kubernetes.io/part-of"] // $DEFAULT')"
-
-      cat > /tmp/console-link.yaml << EOL
-    apiVersion: console.openshift.io/v1
-    kind: ConsoleLink
-    metadata:
-      name: $name
-    spec:
-      applicationMenu:
-        imageURL: "$imageURL"
-        section: "$section"
-      href: "https://$host"
-      location: "$location"
-      text: "$text"
-    EOL
-
-      echo "Creating/updating consolelink: ${name}"
-      kubectl apply -f /tmp/console-link.yaml
-
-      prefix=$(echo ${name^^} | sed "s/-/_/g")
-
-      cat > /tmp/configmap.yaml << EOL
-    apiVersion: v1
-    kind: ConfigMap
-    metadata:
-      name: ${name}-config
-      labels:
-        group: cloud-native-toolkit
-        app.kubernetes.io/component: tools
-        app.kubernetes.io/part-of: ${partOf}
-        app: ${app}
-        app.kubernetes.io/name: ${app}
-      annotations:
-        console-link.cloud-native-toolkit.dev/category: ${category}
-        console-link.cloud-native-toolkit.dev/section: ${section}
-        console-link.cloud-native-toolkit.dev/imageUrl: ${imageUrl}
-        console-link.cloud-native-toolkit.dev/displayName: ${text}
-    spec:
-      ${prefix}_URL: "https://$host"
-    EOL
-
-      echo "Creating/updating configmap: ${name}-config"
-      kubectl apply -n "${namespace}" -f /tmp/configmap.yaml
-    done
   reconcile-ibm-observe-console-links.sh: |
     #!/bin/bash
 
-    DEFAULT_SECTION="Cloud-Native Toolkit"
-    DEFAULT_LOCATION="ApplicationMenu"
+    if [[ -z "${DEFAULT_SECTION}" ]]; then
+      DEFAULT_SECTION="Cloud-Native Toolkit"
+    fi
+
+    if [[ -z "${DEFAULT_LOCATION}" ]]; then
+      DEFAULT_LOCATION="ApplicationMenu"
+    fi
 
     # list all routes with console-link.cloud-native-toolkit.dev/enabled annotation
     DAEMON_SETS=$(kubectl get daemonsets -n ibm-observe -o yaml | yq eval -j '.' - | jq -c '.items[] | del(.metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"])')
@@ -151,3 +78,104 @@ data:
     else
       echo "Console link already exists: ${name}"
     fi
+  reconcile-route-console-links.sh: |
+    #!/bin/bash
+
+    if [[ -z "${DEFAULT_SECTION}" ]]; then
+      DEFAULT_SECTION="Cloud-Native Toolkit"
+    fi
+
+    if [[ -z "${DEFAULT_LOCATION}" ]]; then
+      DEFAULT_LOCATION="ApplicationMenu"
+    fi
+
+    # list all routes and configmaps with console-link.cloud-native-toolkit.dev/enabled label
+    RESOURCES=$(kubectl get routes,configmaps -A -l console-link.cloud-native-toolkit.dev/enabled=true -o yaml | yq eval -j '.' - | jq -c '.items[] | del(.metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"])')
+
+    if [[ -z "${RESOURCES}" ]]; then
+      echo "No resources found with 'console-link.cloud-native-toolkit.dev/enabled=true' label"
+      exit 0
+    fi
+
+    # for each resource create/update a console link
+    echo "${RESOURCES}" | while read -r resource; do
+      namespace="$(echo "${resource}" | jq -r '.metadata.namespace')"
+      name="$(echo "${resource}" | jq -r '.metadata.name')"
+      if [[ -z "${name}" ]]; then
+        echo "Error parsing resource: ${resource}"
+        continue
+      fi
+
+      kind="$(echo "${resource}" | jq -r '.kind')"
+
+      if [[ "${kind}" == "Route" ]]; then
+        host="$(echo "${resource}" | jq -r '.spec.host')"
+        url="https://${host}"
+      elif [[ "${kind}" == "ConfigMap" ]]; then
+        url="$(echo "${resource}" | jq -r '.data.url')"
+      else
+        echo "Unhandled resource: ${kind}"
+        continue
+      fi
+
+      category="$(echo "${resource}" | jq -r '.metadata.annotations["console-link.cloud-native-toolkit.dev/category"] // empty')"
+      section="$(echo "${resource}" | jq -r --arg DEFAULT "${DEFAULT_SECTION}" '.metadata.annotations["console-link.cloud-native-toolkit.dev/section"] // $DEFAULT')"
+      location="$(echo "${resource}" | jq -r --arg DEFAULT "${DEFAULT_LOCATION}" '.metadata.annotations["console-link.cloud-native-toolkit.dev/location"] // $DEFAULT')"
+      imageURL="$(echo "${resource}" | jq -r '.metadata.annotations["console-link.cloud-native-toolkit.dev/imageUrl"] // empty')"
+      text="$(echo "${resource}" | jq -r --arg DEFAULT "$name" '.metadata.annotations["console-link.cloud-native-toolkit.dev/displayName"] // $DEFAULT')"
+
+      app="$(echo "${resource}" | jq -r --arg DEFAULT "${name}" '.metadata.labels["app.kubernetes.io/name"] // $DEFAULT')"
+      if [[ -z "${app}" ]]; then
+        app="$(echo "${resource}" | jq -r --arg DEFAULT "${name}" '.metadata.labels["app"] // $DEFAULT')"
+      fi
+      partOf="$(echo "${resource}" | jq -r --arg DEFAULT "${name}" '.metadata.labels["app.kubernetes.io/part-of"] // $DEFAULT')"
+
+      cat > /tmp/console-link.yaml << EOL
+    apiVersion: console.openshift.io/v1
+    kind: ConsoleLink
+    metadata:
+      name: $name
+    spec:
+      applicationMenu:
+        imageURL: "$imageURL"
+        section: "$section"
+      href: "$url"
+      location: "$location"
+      text: "$text"
+    EOL
+
+      echo "Creating/updating consolelink: ${name}"
+      kubectl apply -f /tmp/console-link.yaml
+
+      if [[ "${kind}" == "ConfigMap" ]]; then
+        echo "ConfigMap already exists. Skipping config map create"
+        continue
+      fi
+
+      prefix=$(echo ${name^^} | sed "s/-/_/g")
+
+      cat > /tmp/configmap.yaml << EOL
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: ${name}-config
+      labels:
+        group: cloud-native-toolkit
+        app.kubernetes.io/component: tools
+        app.kubernetes.io/part-of: ${partOf}
+        app: ${app}
+        app.kubernetes.io/name: ${app}
+      annotations:
+        console-link.cloud-native-toolkit.dev/category: ${category}
+        console-link.cloud-native-toolkit.dev/section: ${section}
+        console-link.cloud-native-toolkit.dev/location: ${location}
+        console-link.cloud-native-toolkit.dev/imageUrl: ${imageUrl}
+        console-link.cloud-native-toolkit.dev/displayName: ${text}
+    spec:
+      ${prefix}_URL: "$url"
+      url: "$url"
+    EOL
+
+      echo "Creating/updating configmap: ${name}-config"
+      kubectl apply -n "${namespace}" -f /tmp/configmap.yaml
+    done


### PR DESCRIPTION
- Adds support for generating console links from config maps (particularly for components hosted outside the cluster)
- Adds README to document usage
- Moves script logic into scripts/ folder and adds _update-configmap.sh to update the contents of templates/configmap.yaml

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>