### PR TITLE
argocd-config: v0.19.0

### DIFF
--- a/stable/argocd-config/Chart.yaml
+++ b/stable/argocd-config/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.18.5
+version: 0.19.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/stable/argocd-config/templates/applications.yaml
+++ b/stable/argocd-config/templates/applications.yaml
@@ -1,6 +1,7 @@
 {{- if include "argocd.repoUrl" . -}}
 {{- $globalNamespace := .Values.global.targetNamespace -}}
 {{- $globalRevision := .Values.global.targetRevision -}}
+{{- $globalPathSuffix := .Values.global.pathSuffix -}}
 {{- $releaseNamespace := .Release.Namespace -}}
 {{- $targetRepo := include "argocd.repoUrl" . -}}
 {{- $project := default "default" .Values.project -}}
@@ -14,6 +15,7 @@
 {{- range .applications -}}
 {{- $name := .name -}}
 {{- $path := default .name .path -}}
+{{- $pathSuffix := default $globalPathSuffix .pathSuffix -}}
 {{- $type := default "helm" .type -}}
 {{- $plugin := .plugin }}
 {{- if $createNamespace }}
@@ -40,7 +42,11 @@ spec:
     server: {{ $server }}
   project: {{ $project }}
   source:
+    {{- if $pathSuffix }}
+    path: {{ "%s/%s" $path $pathSuffix }}
+    {{- else }}
     path: {{ $path }}
+    {{- end }}
     repoURL: {{ $targetRepo }}
     targetRevision: {{ $targetRevision }}
     {{- if eq $type "helm" }}

--- a/stable/argocd-config/values.yaml
+++ b/stable/argocd-config/values.yaml
@@ -15,6 +15,9 @@ global:
   ## The targetRevision to use if one is not provided for the application
   targetRevision: ""
 
+  ## Provides a suffix value (usually a path) that should be added to each path
+  pathSuffix: ""
+
 ## The url of the gitops repo that contains the applications
 repoUrl: ""
 
@@ -50,6 +53,7 @@ applicationTargets: []
 #   - name: app1
 #     type: helm
 #     path: app1
+#     pathSuffix: test
 #   - name: app2
 #     type: directory
 #   - name: app3


### PR DESCRIPTION
- Adds pathSuffix to support defining application paths that include additional path values

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>