### PR TITLE
console-link-configmap: v0.1.0

### DIFF
--- a/stable/console-link-configmap/.helmignore
+++ b/stable/console-link-configmap/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/stable/console-link-configmap/Chart.yaml
+++ b/stable/console-link-configmap/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: console-link-configmap
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 1.16.0

--- a/stable/console-link-configmap/templates/_helpers.tpl
+++ b/stable/console-link-configmap/templates/_helpers.tpl
@@ -1,0 +1,60 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "console-link-configmap.name" -}}
+{{- printf "%s-config" (required "A value is required for the `name` variable" .Values.name) }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "console-link-configmap.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "console-link-configmap.labels" -}}
+helm.sh/chart: {{ include "console-link-configmap.chart" . }}
+{{ include "console-link-configmap.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "console-link-configmap.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "console-link-configmap.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "console-link-configmap.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "console-link-configmap.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "console-link-configmap.section" -}}
+{{- default "Cloud-Native Toolkit" (default .Values.global.section .Values.section) }}
+{{- end }}
+
+{{- define "console-link-configmap.location" -}}
+{{- default "ApplicationMenu" (default .Values.global.location .Values.location) }}
+{{- end }}
+
+{{- define "console-link-configmap.category" -}}
+{{- default .Values.global.category .Values.category }}
+{{- end }}
+
+{{- define "console-link-configmap.displayName" -}}
+{{- default (.Values.name | replace "-" " " | title) .Values.displayName }}
+{{- end }}

--- a/stable/console-link-configmap/templates/configmap.yaml
+++ b/stable/console-link-configmap/templates/configmap.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "console-link-configmap.name" . }}
+  labels:
+    console-link.cloud-native-toolkit.dev/enabled: {{ .Values.enable | quote }}
+    {{- include "console-link-configmap.labels" . | nindent 4 }}
+  annotations:
+    console-link.cloud-native-toolkit.dev/section: {{ include "console-link-configmap.section" .}}
+    console-link.cloud-native-toolkit.dev/location: {{ include "console-link-configmap.location" . }}
+    console-link.cloud-native-toolkit.dev/displayName: {{ include "console-link-configmap.displayName" . }}
+    {{- if .Values.imageUrl }}
+    console-link.cloud-native-toolkit.dev/imageUrl: {{ .Values.imageUrl }}
+    {{- end }}
+    {{- if include "console-link-configmap.category" . }}
+    console-link.cloud-native-toolkit.dev/category: {{ include "console-link-configmap.category" . }}
+    {{- end }}
+data:
+  url: {{ required "A value is required for the `url` variable" .Values.url }}

--- a/stable/console-link-configmap/values.schema.json
+++ b/stable/console-link-configmap/values.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "required": [
+    "enable",
+    "url",
+    "name"
+  ],
+  "properties": {
+    "global": {
+      "type": "object",
+      "properties": {
+        "location": {
+          "type": "string",
+          "enum": ["ApplicationMenu", "HelpMenu", "UserMenu", "NamespaceDashboard", ""]
+        },
+        "section": {
+          "type": "string"
+        },
+        "category": {
+          "type": "string"
+        }
+      }
+    },
+    "enable": {
+      "type": "boolean"
+    },
+    "url": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "location": {
+      "type": "string",
+      "enum": ["ApplicationMenu", "HelpMenu", "UserMenu", "NamespaceDashboard", ""]
+    },
+    "section": {
+      "type": "string"
+    },
+    "category": {
+      "type": "string"
+    },
+    "imageUrl": {
+      "type": "string"
+    },
+    "displayName": {
+      "type": "string"
+    }
+  }
+}

--- a/stable/console-link-configmap/values.yaml
+++ b/stable/console-link-configmap/values.yaml
@@ -1,0 +1,16 @@
+global:
+  location: ""
+  section: ""
+  category: ""
+
+enable: true
+
+url: ""
+name: ""
+
+location: "ApplicationMenu"
+section: "Cloud-Native Toolkit"
+category: ""
+
+imageUrl: ""
+displayName: ""


### PR DESCRIPTION
- Generates a config map with annotations to produce a ConsoleLink in an OpenShift cluster using the console-link-cronjob process

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>