### PR TITLE
developer-dashboard: v1.4.0

### DIFF
--- a/stable/developer-dashboard/Chart.yaml
+++ b/stable/developer-dashboard/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: developer-dashboard
-version: 1.3.1
+version: 1.4.0

--- a/stable/developer-dashboard/values.yaml
+++ b/stable/developer-dashboard/values.yaml
@@ -18,8 +18,8 @@ sso:
   enabled: true
 
 image:
-  repository: ibmgaragecloud/developer-dashboard
-  tag: 1.1.1
+  repository: quay.io/ibmgaragecloud/developer-dashboard
+  tag: v1.4.4
   pullPolicy: IfNotPresent
   port: 3000
   repoUrl: "https://github.com/ibm-garage-cloud/developer-dashboard"


### PR DESCRIPTION
- Updates default repository url to quay.io/ibmgaragecloud/developer-dashboard
- Updates default tag to v1.4.4

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>