### PR TITLE
console-link-cronjob: v0.4.1

### DIFF
--- a/stable/console-link-cronjob/Chart.yaml
+++ b/stable/console-link-cronjob/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/console-link-cronjob/templates/cronjob.yaml
+++ b/stable/console-link-cronjob/templates/cronjob.yaml
@@ -25,8 +25,8 @@ spec:
                   name: scripts
               env:
                 - name: LOGGING_IMAGE
-                  value: {{ .Values.loggingImageUrl }}
+                  value: {{ .Values.loggingImageUrl | quote }}
                 - name: MONITORING_IMAGE
-                  value: {{ .Values.monitoringImageUrl }}
+                  value: {{ .Values.monitoringImageUrl | quote }}
               command:
                 - /scripts/reconcile-route-console-links.sh || echo "Route error"; /scripts/reconcile-ibm-observe-console-links.sh


### PR DESCRIPTION
- Wraps monitor and logging images strings in quotes for environment variables to prevent issues

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>