### PR TITLE
console-link-cronjob: v0.5.0

### DIFF
--- a/stable/console-link-cronjob/Chart.yaml
+++ b/stable/console-link-cronjob/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.2
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/console-link-cronjob/scripts/reconcile-ibm-observe-console-links.sh
+++ b/stable/console-link-cronjob/scripts/reconcile-ibm-observe-console-links.sh
@@ -8,16 +8,24 @@ if [[ -z "${DEFAULT_LOCATION}" ]]; then
   DEFAULT_LOCATION="ApplicationMenu"
 fi
 
+NAMESPACE="ibm-observe"
+
 # list all routes with console-link.cloud-native-toolkit.dev/enabled annotation
-DAEMON_SETS=$(kubectl get daemonsets -n ibm-observe -o yaml | yq eval -j '.' - | jq -c '.items[] | del(.metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"])')
+DAEMON_SETS=$(kubectl get daemonsets -n "${NAMESPACE}" -o yaml | yq eval -j '.' - | jq -c '.items[] | del(.metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"])')
 
 AGENT_NAME=$(echo "${DAEMON_SETS}" | jq 'select(.metadata.name = "logdna-agent") | .metadata.name // empty')
 name="ibm-logging"
 imageURL="${LOGGING_IMAGE}"
 text="IBM Log Analysis"
+type="logging"
 url="https://cloud.ibm.com/observe/logging"
 
 if [[ -n "${AGENT_NAME}" ]] && ! kubectl get consolelink "${name}" 1> /dev/null 2> /dev/null; then
+  guid=$(kubectl get configmap -n "${NAMESPACE}" -o json | jq --arg NAME "${AGENT_NAME}" '.items | .[] | select(.data.daemonsetName == $NAME) | .metadata.name')
+  if [[ -n "${guid}" ]]; then
+    url="https://cloud.ibm.com/observe/embedded-view/${type}/${guid}"
+  fi
+
   cat > /tmp/console-link.yaml << EOL
 apiVersion: console.openshift.io/v1
 kind: ConsoleLink
@@ -45,9 +53,15 @@ AGENT_NAME=$(echo "${DAEMON_SETS}" | jq 'select(.metadata.name = "sysdig-agent")
 name="ibm-monitoring"
 imageURL="${MONITORING_IMAGE}"
 text="IBM Monitoring"
+type="monitoring"
 url="https://cloud.ibm.com/observe/monitoring"
 
 if [[ -n "${AGENT_NAME}" ]] && ! kubectl get consolelink "${name}" 1> /dev/null 2> /dev/null; then
+  guid=$(kubectl get configmap -n "${NAMESPACE}" -o json | jq --arg NAME "${AGENT_NAME}" '.items | .[] | select(.data.daemonsetName == $NAME) | .metadata.name')
+  if [[ -n "${guid}" ]]; then
+    url="https://cloud.ibm.com/observe/embedded-view/${type}/${guid}"
+  fi
+
   cat > /tmp/console-link.yaml << EOL
 apiVersion: console.openshift.io/v1
 kind: ConsoleLink

--- a/stable/console-link-cronjob/templates/configmap.yaml
+++ b/stable/console-link-cronjob/templates/configmap.yaml
@@ -16,16 +16,24 @@ data:
       DEFAULT_LOCATION="ApplicationMenu"
     fi
 
+    NAMESPACE="ibm-observe"
+
     # list all routes with console-link.cloud-native-toolkit.dev/enabled annotation
-    DAEMON_SETS=$(kubectl get daemonsets -n ibm-observe -o yaml | yq eval -j '.' - | jq -c '.items[] | del(.metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"])')
+    DAEMON_SETS=$(kubectl get daemonsets -n "${NAMESPACE}" -o yaml | yq eval -j '.' - | jq -c '.items[] | del(.metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"])')
 
     AGENT_NAME=$(echo "${DAEMON_SETS}" | jq 'select(.metadata.name = "logdna-agent") | .metadata.name // empty')
     name="ibm-logging"
     imageURL="${LOGGING_IMAGE}"
     text="IBM Log Analysis"
+    type="logging"
     url="https://cloud.ibm.com/observe/logging"
 
     if [[ -n "${AGENT_NAME}" ]] && ! kubectl get consolelink "${name}" 1> /dev/null 2> /dev/null; then
+      guid=$(kubectl get configmap -n "${NAMESPACE}" -o json | jq --arg NAME "${AGENT_NAME}" '.items | .[] | select(.data.daemonsetName == $NAME) | .metadata.name')
+      if [[ -n "${guid}" ]]; then
+        url="https://cloud.ibm.com/observe/embedded-view/${type}/${guid}"
+      fi
+
       cat > /tmp/console-link.yaml << EOL
     apiVersion: console.openshift.io/v1
     kind: ConsoleLink
@@ -53,9 +61,15 @@ data:
     name="ibm-monitoring"
     imageURL="${MONITORING_IMAGE}"
     text="IBM Monitoring"
+    type="monitoring"
     url="https://cloud.ibm.com/observe/monitoring"
 
     if [[ -n "${AGENT_NAME}" ]] && ! kubectl get consolelink "${name}" 1> /dev/null 2> /dev/null; then
+      guid=$(kubectl get configmap -n "${NAMESPACE}" -o json | jq --arg NAME "${AGENT_NAME}" '.items | .[] | select(.data.daemonsetName == $NAME) | .metadata.name')
+      if [[ -n "${guid}" ]]; then
+        url="https://cloud.ibm.com/observe/embedded-view/${type}/${guid}"
+      fi
+
       cat > /tmp/console-link.yaml << EOL
     apiVersion: console.openshift.io/v1
     kind: ConsoleLink


### PR DESCRIPTION
- Adds logic to reconsole-ibm-observe-console-links.sh to determine the guid (and therefore the correct url to the service) from the configmap

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>