### PR TITLE
starter-kit: v0.6.1

### DIFF
--- a/stable/starter-kit/Chart.yaml
+++ b/stable/starter-kit/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 ## This is the chart version. This version number should be incremented each time you make changes
 ## to the chart and its templates, including the app version.
 ## Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.6.1
 
 ## This is the version number of the application being deployed. This version number should be
 ## incremented each time you make changes to the application. Versions are not expected to

--- a/stable/starter-kit/templates/deployment.yaml
+++ b/stable/starter-kit/templates/deployment.yaml
@@ -63,9 +63,13 @@ spec:
             {{- toYaml .Values.envFrom | nindent 12 }}
             {{- end }}
           {{- end }}
-          {{- if .Values.env }}
           env:
-            {{- toYaml .Values.env | nindent 12 }}
+            - name: JAEGER_SERVICE_NAME
+              value: {{ include "starter-kit.fullname" . }}
+            - name: IMAGE_NAME
+              value: {{ include "starter-kit.fullname" . }}
+          {{- if .Values.env }}
+          {{- toYaml .Values.env | nindent 12 }}
           {{- end }}
           ports:
             - name: http


### PR DESCRIPTION
- Adds JAEGER_SERVICE_NAME and IMAGE_NAME environment variables to the deployment

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>