### PR TITLE
starter-kit: v0.6.2

### DIFF
--- a/stable/starter-kit/Chart.yaml
+++ b/stable/starter-kit/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 ## This is the chart version. This version number should be incremented each time you make changes
 ## to the chart and its templates, including the app version.
 ## Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.1
+version: 0.6.2
 
 ## This is the version number of the application being deployed. This version number should be
 ## incremented each time you make changes to the application. Versions are not expected to

--- a/stable/starter-kit/templates/_helpers.tpl
+++ b/stable/starter-kit/templates/_helpers.tpl
@@ -130,3 +130,27 @@ requests:
   memory: 128Mi
 {{- end -}}
 {{- end -}}
+
+
+{{- define "starter-kit.initialDelaySeconds" -}}
+{{- if .Values.initialDelaySeconds -}}
+{{ .Values.initialDelaySeconds }}
+{{- else -}}
+{{ include "starter-kit.default-initialDelaySeconds" . }}
+{{- end -}}
+{{- end -}}
+
+{{- define "starter-kit.default-initialDelaySeconds" -}}
+{{- $runtime := .Values.runtime -}}
+{{- if eq $runtime "golang" -}}
+5
+{{- else if or (eq $runtime "js") (eq $runtime "nodejs") -}}
+5
+{{- else if or (or (eq $runtime "openjdk") (eq $runtime "spring")) (eq $runtime "openliberty") -}}
+60
+{{- else if eq $runtime "python" -}}
+5
+{{- else -}}
+60
+{{- end -}}
+{{- end -}}

--- a/stable/starter-kit/templates/deployment.yaml
+++ b/stable/starter-kit/templates/deployment.yaml
@@ -78,9 +78,19 @@ spec:
           livenessProbe:
             tcpSocket:
               port: http
+            initialDelaySeconds: {{ include "starter-kit.initialDelaySeconds" . }}
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             tcpSocket:
               port: http
+            initialDelaySeconds: {{ include "starter-kit.initialDelaySeconds" . }}
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {{- include "starter-kit.resources" . | nindent 12 }}
         {{- if .Values.graphql.enabled }}


### PR DESCRIPTION
- Determines appropriate initialDelaySeconds value for liveness and reqdiness probes based on runtime value

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>