### PR TITLE
Modified charts for infraconfig and ocs-operator 

### DIFF
--- a/stable/ocs-operator/Chart.yaml
+++ b/stable/ocs-operator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/ocs-operator/templates/storage-storagecluster.yaml
+++ b/stable/ocs-operator/templates/storage-storagecluster.yaml
@@ -12,8 +12,6 @@ spec:
   - config: {}
     count: 1
     dataPVCTemplate:
-      metadata:
-        creationTimestamp: null
       spec:
         accessModes:
         - ReadWriteOnce

--- a/stable/refarch-infraconfig/Chart.yaml
+++ b/stable/refarch-infraconfig/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/refarch-infraconfig/templates/infrastructure-imageregistry.yaml
+++ b/stable/refarch-infraconfig/templates/infrastructure-imageregistry.yaml
@@ -31,9 +31,6 @@ spec:
         - name: config
           image: quay.io/openshift/origin-cli:latest
           command: ["oc"]
-          envFrom:
-            configMapRef:
-            prefix: INFRACONFIG_
           args:
             - patch
             - configs.imageregistry.operator.openshift.io/cluster

--- a/stable/refarch-infraconfig/templates/infrastructure-imageregistry.yaml
+++ b/stable/refarch-infraconfig/templates/infrastructure-imageregistry.yaml
@@ -45,6 +45,9 @@ spec:
             requests:
               cpu: "2500m"
               memory: "64Mi"
+            limits:
+              cpu: "2500m"
+              memory: "256Mi"
       restartPolicy: Never
       serviceAccountName: {{ .Values.argo.serviceAccount | default "argocd-server" }}
   backoffLimit: 4

--- a/stable/refarch-infraconfig/templates/infrastructure-imageregistry.yaml
+++ b/stable/refarch-infraconfig/templates/infrastructure-imageregistry.yaml
@@ -41,6 +41,10 @@ spec:
             {{- else }}
             - '{"spec": {"nodeSelector": {"node-role.kubernetes.io/infra": ""},"tolerations": [{"effect": "NoSchedule", "key": "infra", "value": ""}]}}'
             {{- end }}
+          resources:
+            requests:
+              cpu: "2500m"
+              memory: "64Mi"
       restartPolicy: Never
       serviceAccountName: {{ .Values.argo.serviceAccount | default "argocd-server" }}
   backoffLimit: 4

--- a/stable/refarch-infraconfig/templates/infrastructure-ingresscontroller.yaml
+++ b/stable/refarch-infraconfig/templates/infrastructure-ingresscontroller.yaml
@@ -25,6 +25,9 @@ spec:
             requests:
               cpu: "2500m"
               memory: "64Mi"
+            limits:
+              cpu: "2500m"
+              memory: "256Mi"
       restartPolicy: Never
       serviceAccountName: {{ .Values.argo.serviceAccount | default "argocd-server" }}
   backoffLimit: 4

--- a/stable/refarch-infraconfig/templates/infrastructure-ingresscontroller.yaml
+++ b/stable/refarch-infraconfig/templates/infrastructure-ingresscontroller.yaml
@@ -21,6 +21,10 @@ spec:
             - --type=merge
             - -p
             - '{"spec": {"replicas": {{ $.Values.ingress.replicas }}, "nodePlacement": {"nodeSelector": {"matchLabels": {"node-role.kubernetes.io/infra": ""}},"tolerations": [{"effect":"NoSchedule", "key": "infra", "value": ""}]}}}'
+          resources:
+            requests:
+              cpu: "2500m"
+              memory: "64Mi"
       restartPolicy: Never
       serviceAccountName: {{ .Values.argo.serviceAccount | default "argocd-server" }}
   backoffLimit: 4


### PR DESCRIPTION
Helm charts generates error from envFrom under pod. 