### PR TITLE
assign-group-cronjob: v0.2.0

### DIFF
--- a/stable/assign-group-cronjob/Chart.yaml
+++ b/stable/assign-group-cronjob/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/assign-group-cronjob/templates/configmap.yaml
+++ b/stable/assign-group-cronjob/templates/configmap.yaml
@@ -8,8 +8,8 @@ data:
   reconcile-users-in-group.sh: |
     #!/bin/bash
 
-    if [[ -z "${GROUP_NAME}" ]]; then
-      echo "Group name not set"
+    if [[ -z "${GROUP_NAMES}" ]]; then
+      echo "GROUP_NAMES not set"
       exit 1
     fi
 
@@ -27,12 +27,15 @@ data:
       exit 0
     fi
 
-    kubectl get group "${GROUP_NAME}" -o json > /tmp/group.json
+    echo "${GROUP_NAMES}" | jq -r '.[]' | while read group_name; do
+      echo "Processing group: ${group_name}"
+      kubectl get group "${group_name}" -o json > /tmp/group.json
 
-    GROUP_USERS=$(cat /tmp/group.json | jq -c '.users | {"users": .}')
-    cat /tmp/group.json | jq --arg MANAGED_BY $MANAGED_BY 'del(.users) | .metadata.labels["app.kubernetes.io/managed-by"] = $MANAGED_BY' > /tmp/group-nousers.json
+      GROUP_USERS=$(cat /tmp/group.json | jq -c '.users | {"users": .}')
+      cat /tmp/group.json | jq --arg MANAGED_BY $MANAGED_BY 'del(.users) | .metadata.labels["app.kubernetes.io/managed-by"] = $MANAGED_BY' > /tmp/group-nousers.json
 
-    if [[ "${USERS}" != "${GROUP_USERS}" ]]; then
-      echo "Reconciling users to group"
-      echo "${USERS}" | jq -s '.[0] * .[1]' /tmp/group-nousers.json - | kubectl apply -f -
-    fi
+      if [[ "${USERS}" != "${GROUP_USERS}" ]]; then
+        echo "Reconciling users to group"
+        echo "${USERS}" | jq -s '.[0] * .[1]' /tmp/group-nousers.json - | kubectl apply -f -
+      fi
+    done

--- a/stable/assign-group-cronjob/templates/cronjob.yaml
+++ b/stable/assign-group-cronjob/templates/cronjob.yaml
@@ -26,8 +26,8 @@ spec:
                 - mountPath: /scripts
                   name: scripts
               env:
-                - name: GROUP_NAME
-                  value: {{ .Values.groupName }}
+                - name: GROUP_NAMES
+                  value: {{ .Values.groupNames | toJson | quote }}
                 - name: JOB_NAME
                   value: {{ include "console-link-cronjob.fullname" . }}
                 - name: NAMESPACE

--- a/stable/assign-group-cronjob/values.yaml
+++ b/stable/assign-group-cronjob/values.yaml
@@ -13,5 +13,5 @@ serviceAccount:
 image: quay.io/cloudnativetoolkit/console-link-cronjob
 imageTag: ""
 
-groupName: ""
+groupNames: []
 


### PR DESCRIPTION
- Adds support for providing a list of groups to assign users

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>