### PR TITLE
console-link-configmap: v0.2.0

### DIFF
--- a/stable/console-link-configmap/Chart.yaml
+++ b/stable/console-link-configmap/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/console-link-configmap/templates/_helpers.tpl
+++ b/stable/console-link-configmap/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 Expand the name of the chart.
 */}}
 {{- define "console-link-configmap.name" -}}
-{{- printf "%s-config" (required "A value is required for the `name` variable" .Values.name) }}
+{{- printf "%s-config" (required "A value is required for the `name` variable" .Values.name | default "cm") }}
 {{- end }}
 
 {{/*

--- a/stable/console-link-configmap/templates/configmap.yaml
+++ b/stable/console-link-configmap/templates/configmap.yaml
@@ -17,3 +17,6 @@ metadata:
     {{- end }}
 data:
   url: {{ required "A value is required for the `url` variable" .Values.url }}
+  {{- if .Values.otherValues }}
+  {{- .Values.otherValues | toYaml | nindent 2 }}
+  {{- end }}

--- a/stable/console-link-configmap/values.schema.json
+++ b/stable/console-link-configmap/values.schema.json
@@ -45,6 +45,9 @@
     },
     "displayName": {
       "type": "string"
+    },
+    "otherValues": {
+      "type": "object"
     }
   }
 }

--- a/stable/console-link-configmap/values.yaml
+++ b/stable/console-link-configmap/values.yaml
@@ -14,3 +14,5 @@ category: ""
 
 imageUrl: ""
 displayName: ""
+
+otherValues: {}


### PR DESCRIPTION
- Adds otherValues entry to values to allow more data than url to be added to the configmap

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>