### PR TITLE
tool-config: v0.12.1

### DIFF
--- a/stable/tool-config/Chart.yaml
+++ b/stable/tool-config/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart to create a ConfigMap and Secret containing the configuration information for a deployed tool
 name: tool-config
-version: 0.12.0
+version: 0.12.1

--- a/stable/tool-config/templates/_helpers.tpl
+++ b/stable/tool-config/templates/_helpers.tpl
@@ -112,3 +112,11 @@ Create chart name and version as used by the chart label.
 {{- "" -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "tool-config.consoleLinkEnabled" -}}
+{{- if (and .Values.enableConsoleLink .Values.url) -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}

--- a/stable/tool-config/templates/config-map.yaml
+++ b/stable/tool-config/templates/config-map.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ include "tool-config.config-name" . }}
   labels:
-    console-link.cloud-native-toolkit.dev/enabled: {{ (and .Values.enableConsoleLink (include "tool-config.url" .)) | quote }}
+    console-link.cloud-native-toolkit.dev/enabled: {{ include "tool-config.consoleLinkEnabled" . | quote }}
     {{ include "tool-config.labels" . | nindent 4 }}
   annotations:
     description: {{ printf "Config map to hold the url for %s in the environment so that other components can access it" (include "tool-config.name" .) }}


### PR DESCRIPTION
- Fixes logic for console-link.cloud-native-toolkit.dev/enabled label

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>