### PR TITLE
ibm-catalogs: v0.3.0

### DIFF
--- a/stable/ibm-catalogs/Chart.yaml
+++ b/stable/ibm-catalogs/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.3
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/stable/ibm-catalogs/templates/ibm-automation-foundation-core-operator-catalog.yaml
+++ b/stable/ibm-catalogs/templates/ibm-automation-foundation-core-operator-catalog.yaml
@@ -3,5 +3,7 @@ kind: CatalogSource
 metadata:
   name: iaf-core-operators
   namespace: openshift-marketplace
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ .Values.syncWave | default "-10" | quote }}
 spec:
   {{- toYaml .Values.catalogs.automationfoundation.catalog | nindent 2 }}

--- a/stable/ibm-catalogs/templates/ibm-common-services-operator-catalog.yaml
+++ b/stable/ibm-catalogs/templates/ibm-common-services-operator-catalog.yaml
@@ -3,5 +3,7 @@ kind: CatalogSource
 metadata:
   name: opencloud-operators
   namespace: openshift-marketplace
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ .Values.syncWave | default "-10" | quote }}
 spec:
   {{- toYaml .Values.catalogs.commonservices.catalog | nindent 2 }}

--- a/stable/ibm-catalogs/templates/ibm-operator-catalog.yaml
+++ b/stable/ibm-catalogs/templates/ibm-operator-catalog.yaml
@@ -3,5 +3,7 @@ kind: CatalogSource
 metadata:
   name: ibm-operator-catalog
   namespace: openshift-marketplace
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ .Values.syncWave | default "-10" | quote }}
 spec:
   {{- toYaml .Values.catalogs.ibmoperators.catalog | nindent 2 }}

--- a/stable/ibm-catalogs/templates/ibm-process-mining-operator-catalog.yaml
+++ b/stable/ibm-catalogs/templates/ibm-process-mining-operator-catalog.yaml
@@ -3,5 +3,7 @@ kind: CatalogSource
 metadata:
   name: ibm-automation-processminings
   namespace: openshift-marketplace
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ .Values.syncWave | default "-10" | quote }}
 spec:
   {{- toYaml .Values.catalogs.processmining.catalog | nindent 2 }}

--- a/stable/ibm-catalogs/values.yaml
+++ b/stable/ibm-catalogs/values.yaml
@@ -1,6 +1,8 @@
 # Default values for ibm-catalogs.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+syncWave: "-10"
+
 catalogs:
   commonservices:
     name: opencloud-operators


### PR DESCRIPTION
- Adds sync-wave annotation and input value to install the catalog before the operators

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>