### PR TITLE
argocd-operator: v0.5.0

### DIFF
--- a/stable/argocd-operator/Chart.yaml
+++ b/stable/argocd-operator/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.4.0
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/stable/argocd-operator/templates/rbac.yaml
+++ b/stable/argocd-operator/templates/rbac.yaml
@@ -1,9 +1,10 @@
 {{- if .Values.controllerRbac -}}
 {{- $releaseNamespace := .Release.Namespace -}}
+{{- $name := printf "%s-argocd" $releaseNamespace }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ printf "%s-argocd" $releaseNamespace }}
+  name: {{ $name }}
   labels:
     {{ include "operator.labels" . | nindent 4 }}
 rules:
@@ -17,22 +18,17 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ printf "%s-argocd" $releaseNamespace }}
+  name: {{ $name }}
   labels:
     {{ include "operator.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ printf "%s-argocd" $releaseNamespace }}
+  name: {{ $name }}
 subjects:
-- kind: ServiceAccount
-  name: argocd-application-controller
-  namespace: {{ $releaseNamespace }}
-- kind: ServiceAccount
-  name: argocd-server
-  namespace: {{ $releaseNamespace }}
-- kind: ServiceAccount
-  name: job-{{ include "operator.name" . }}
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: {{ printf "system:serviceaccounts:%s" $releaseNamespace | quote }}
   namespace: {{ $releaseNamespace }}
 ---
 {{- end -}}


### PR DESCRIPTION
- Updates controller RBAC to use the service account group for the subject

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>