### PR TITLE
openshift-gitops: v0.8.0

### DIFF
--- a/stable/openshift-gitops/Chart.yaml
+++ b/stable/openshift-gitops/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.7.0
+version: 0.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/stable/openshift-gitops/templates/rbac.yaml
+++ b/stable/openshift-gitops/templates/rbac.yaml
@@ -1,9 +1,10 @@
 {{- if .Values.controllerRbac -}}
 {{- $releaseNamespace := "openshift-gitops" -}}
+{{- $name := printf "%s-argocd" $releaseNamespace }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ printf "%s-argocd" $releaseNamespace }}
+  name: {{ $name }}
   labels:
     {{ include "operator.labels" . | nindent 4 }}
 rules:
@@ -17,26 +18,17 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ printf "%s-argocd" $releaseNamespace }}
+  name: {{ $name }}
   labels:
     {{ include "operator.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ printf "%s-argocd" $releaseNamespace }}
+  name: {{ $name }}
 subjects:
-- kind: ServiceAccount
-  name: openshift-gitops-argocd-application-controller
-  namespace: {{ $releaseNamespace }}
-- kind: ServiceAccount
-  name: argocd-cluster-argocd-application-controller
-  namespace: {{ $releaseNamespace }}
-- kind: ServiceAccount
-  name: argocd-application-controller
-  namespace: {{ $releaseNamespace }}
-- kind: ServiceAccount
-  name: argocd-server
-  namespace: {{ $releaseNamespace }}
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: {{ printf "systen:serviceaccounts:%s" $releaseNamespace | quote }}
 - kind: ServiceAccount
   name: job-{{ include "operator.name" . }}
   namespace: {{ include "operator.operator-namespace" . }}


### PR DESCRIPTION
- Updates controller RBAC to use the service account group for the subject

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>