### PR TITLE
ibm-platform-navigator: v0.3.0

### DIFF
--- a/stable/ibm-platform-navigator/Chart.yaml
+++ b/stable/ibm-platform-navigator/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.1
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/stable/ibm-platform-navigator/templates/subscription.yaml
+++ b/stable/ibm-platform-navigator/templates/subscription.yaml
@@ -2,5 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: {{ .Values.subscriptions.platformnavigator.name }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ .Values.syncWave | default "-5" | quote }}
 spec:
   {{- toYaml .Values.subscriptions.platformnavigator.subscription | nindent 2 }}

--- a/stable/ibm-platform-navigator/values.yaml
+++ b/stable/ibm-platform-navigator/values.yaml
@@ -2,6 +2,8 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+syncWave: "-5"
+
 subscriptions:
   platformnavigator:
     name: ibm-platform-navigator


### PR DESCRIPTION
- Sets sync-wave annotation to -5

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>