### PR TITLE
openshift-gitops-instance: v0.2.0

### DIFF
--- a/stable/openshift-gitops-instance/Chart.yaml
+++ b/stable/openshift-gitops-instance/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/stable/openshift-gitops-instance/values.yaml
+++ b/stable/openshift-gitops-instance/values.yaml
@@ -53,7 +53,11 @@ openshiftgitops:
           requests:
             cpu: 250m
             memory: 512Mi
-      rbac: {}
+      rbac:
+        defaultPolicy: 'role:readonly'
+        policy: |
+          g, argocd-admins, role:admin
+        scopes: '[groups]'
       repo:
         resources:
           limits:
@@ -71,6 +75,7 @@ openshiftgitops:
           - TaskRun
           - PipelineRun
       dex:
+        openShiftOAuth: true
         resources:
           limits:
             cpu: 500m


### PR DESCRIPTION
- Adds default configuration for RBAC
- Enables openShiftOAuth by default

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>