### PR TITLE
service-signed-cert: v0.3.0

### DIFF
--- a/stable/service-signed-cert/Chart.yaml
+++ b/stable/service-signed-cert/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.4
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/service-signed-cert/scripts/create-secret.sh
+++ b/stable/service-signed-cert/scripts/create-secret.sh
@@ -45,5 +45,14 @@ oc create secret generic ${SECRET_NAME} \
   --from-file=key.pem="${CERT_DIR}"/server-key.pem \
   --from-file=cert.pem="${CERT_DIR}"/server-cert.pem \
   --dry-run=client \
-  -o yaml |
+  -o yaml | \
   oc -n ${NAMESPACE} apply -f -
+
+if [[ -n "${CA_CONFIG_MAP_NAME}" ]]; then
+  oc get cm -n "${NAMESPACE}" kube-root-ca.crt -o jsonpath='{ .data.ca\.crt }' | base64 -D > "${CERT_DIR}/ca.crt"
+  oc create configmap ${CA_CONFIG_MAP_NAME} \
+    --from-file=ca.crt="${CERT_DIR}/ca.crt" \
+    --dry-run=client \
+    -o yaml | \
+    oc -n "${NAMESPACE}" apply -f -
+fi

--- a/stable/service-signed-cert/templates/configmap.yaml
+++ b/stable/service-signed-cert/templates/configmap.yaml
@@ -166,8 +166,17 @@ data:
       --from-file=key.pem="${CERT_DIR}"/server-key.pem \
       --from-file=cert.pem="${CERT_DIR}"/server-cert.pem \
       --dry-run=client \
-      -o yaml |
+      -o yaml | \
       oc -n ${NAMESPACE} apply -f -
+
+    if [[ -n "${CA_CONFIG_MAP_NAME}" ]]; then
+      oc get cm -n "${NAMESPACE}" kube-root-ca.crt -o jsonpath='{ .data.ca\.crt }' | base64 -D > "${CERT_DIR}/ca.crt"
+      oc create configmap ${CA_CONFIG_MAP_NAME} \
+        --from-file=ca.crt="${CERT_DIR}/ca.crt" \
+        --dry-run=client \
+        -o yaml | \
+        oc -n "${NAMESPACE}" apply -f -
+    fi
   wait-for-csr.sh: |
     #!/bin/bash
 

--- a/stable/service-signed-cert/templates/job.yaml
+++ b/stable/service-signed-cert/templates/job.yaml
@@ -81,6 +81,10 @@ spec:
               value: {{ .Values.serviceName }}
             - name: SECRET_NAME
               value: {{ required "The secretName is required" .Values.secretName }}
+            {{- if .Values.caConfigName }}
+            - name: CA_CONFIG_MAP_NAME
+              value: {{ .Values.caConfigName }}
+            {{- end }}
             - name: CERT_DIR
               value: /opt/certs
           volumeMounts:

--- a/stable/service-signed-cert/templates/rbac.yaml
+++ b/stable/service-signed-cert/templates/rbac.yaml
@@ -48,7 +48,7 @@ metadata:
 {{ include "service-signed-cert.labels" . | nindent 4 }}
 rules:
   - apiGroups: [""]
-    resources: ["secrets"]
+    resources: ["secrets","configmaps"]
     verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/stable/service-signed-cert/values.yaml
+++ b/stable/service-signed-cert/values.yaml
@@ -14,3 +14,4 @@ serviceAccount:
 
 serviceName: ""
 secretName: ""
+caConfigName: ""


### PR DESCRIPTION
Adds support for caConfigName variable and logic to save ca cert in configmap

Closes #323

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>