### PR TITLE
ibm-portworx: v0.2.4

### DIFF
--- a/stable/ibm-portworx/Chart.yaml
+++ b/stable/ibm-portworx/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.3
+version: 0.2.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/ibm-portworx/templates/post-delete-hook.yaml
+++ b/stable/ibm-portworx/templates/post-delete-hook.yaml
@@ -104,6 +104,12 @@ rules:
       - "clusterroles"
     verbs:
       - "*"
+  - apiGroups:
+      - "ibmcloud.ibm.com"
+    resources:
+      - "services"
+    verbs:
+      - "*"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
- Adds ibmcloud.ibm.com/services to the RBAC rules for the delete service account

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>