### PR TITLE
ibmcloud-operator: v0.2.2

### DIFF
--- a/stable/ibmcloud-operator/Chart.yaml
+++ b/stable/ibmcloud-operator/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.1
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/stable/ibmcloud-operator/templates/subscription.yaml
+++ b/stable/ibmcloud-operator/templates/subscription.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "operator.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-install
     argocd.argoproj.io/sync-wave: "-5"
 spec:
   channel: {{ include "operator.channel" . }}


### PR DESCRIPTION
- Removes pre-install helm hook annotation

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>