### PR TITLE
ibm-portworx: v0.3.0

### DIFF
--- a/stable/ibm-portworx/Chart.yaml
+++ b/stable/ibm-portworx/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.7
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/ibm-portworx/templates/portworx-service.yaml
+++ b/stable/ibm-portworx/templates/portworx-service.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "ibm-portworx.service-name" . }}
   labels:
     {{- include "ibm-portworx.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    helm.sh/hook-weight: "-1"
 spec:
   plan: {{ .Values.plan }}
   serviceClass: portworx

--- a/stable/ibm-portworx/templates/storageclasses.yaml
+++ b/stable/ibm-portworx/templates/storageclasses.yaml
@@ -1,0 +1,509 @@
+# CouchDB (Implemented application-level redundancy)
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: portworx-couchdb-sc
+  labels:
+    {{- include "ibm-portworx.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    helm.sh/hook-weight: "-1"
+provisioner: kubernetes.io/portworx-volume
+parameters:
+  repl: "3"
+  priority_io: "high"
+  io_profile: "db_remote"
+  disable_io_profile_protection: "1"
+allowVolumeExpansion: true
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+---
+# ElasticSearch (Implemented application-level redundancy)
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: portworx-elastic-sc
+  labels:
+    {{- include "ibm-portworx.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    helm.sh/hook-weight: "-1"
+provisioner: kubernetes.io/portworx-volume
+parameters:
+  repl: "2"
+  priority_io: "high"
+  io_profile: "db_remote"
+  disable_io_profile_protection: "1"
+allowVolumeExpansion: true
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+---
+# Solr
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: portworx-solr-sc
+  labels:
+    {{- include "ibm-portworx.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    helm.sh/hook-weight: "-1"
+provisioner: kubernetes.io/portworx-volume
+parameters:
+  repl: "3"
+  priority_io: "high"
+  io_profile: "db_remote"
+  disable_io_profile_protection: "1"
+allowVolumeExpansion: true
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+---
+# Cassandra
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: portworx-cassandra-sc
+  labels:
+    {{- include "ibm-portworx.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    helm.sh/hook-weight: "-1"
+provisioner: kubernetes.io/portworx-volume
+parameters:
+  repl: "3"
+  priority_io: "high"
+  io_profile: "db_remote"
+  disable_io_profile_protection: "1"
+allowVolumeExpansion: true
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+---
+# Kafka
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: portworx-kafka-sc
+  labels:
+    {{- include "ibm-portworx.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    helm.sh/hook-weight: "-1"
+provisioner: kubernetes.io/portworx-volume
+parameters:
+  repl: "3"
+  priority_io: "high"
+  io_profile: "db_remote"
+  disable_io_profile_protection: "1"
+allowVolumeExpansion: true
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+---
+# metastoredb:
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: portworx-metastoredb-sc
+  labels:
+    {{- include "ibm-portworx.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    helm.sh/hook-weight: "-1"
+parameters:
+  priority_io: high
+  io_profile: db_remote
+  repl: "3"
+  disable_io_profile_protection: "1"
+allowVolumeExpansion: true
+provisioner: kubernetes.io/portworx-volume
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+---
+# General Purpose, 3 Replicas - Default SC for other applications
+# without specific SC defined and with RWX volume access mode - New Install
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: portworx-rwx-gp3-sc
+  labels:
+    {{- include "ibm-portworx.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    helm.sh/hook-weight: "-1"
+parameters:
+  priority_io: high
+  repl: "3"
+  sharedv4: "true"
+  io_profile: db_remote
+  disable_io_profile_protection: "1"
+allowVolumeExpansion: true
+provisioner: kubernetes.io/portworx-volume
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+---
+# General Purpose, 3 Replicas [Default for other applications without
+# specific SC defined and with RWX volume access mode] - SC portworx-shared-gp3 for upgrade purposes
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: portworx-shared-gp3
+  labels:
+    {{- include "ibm-portworx.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    helm.sh/hook-weight: "-1"
+parameters:
+  priority_io: high
+  repl: "3"
+  sharedv4: "true"
+  io_profile: db_remote
+  disable_io_profile_protection: "1"
+allowVolumeExpansion: true
+provisioner: kubernetes.io/portworx-volume
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+---
+# General Purpose, 2 Replicas RWX volumes
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: portworx-rwx-gp2-sc
+  labels:
+    {{- include "ibm-portworx.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    helm.sh/hook-weight: "-1"
+parameters:
+  priority_io: high
+  repl: "2"
+  sharedv4: "true"
+  io_profile: db_remote
+  disable_io_profile_protection: "1"
+allowVolumeExpansion: true
+provisioner: kubernetes.io/portworx-volume
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+---
+# DV - Single replica
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: portworx-dv-shared-gp
+  labels:
+    {{- include "ibm-portworx.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    helm.sh/hook-weight: "-1"
+parameters:
+  block_size: 4096b
+  priority_io: high
+  repl: "1"
+  shared: "true"
+provisioner: kubernetes.io/portworx-volume
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+---
+# DV - three replicas
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: portworx-dv-shared-gp3
+  labels:
+    {{- include "ibm-portworx.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    helm.sh/hook-weight: "-1"
+parameters:
+  block_size: 4096b
+  priority_io: high
+  repl: "3"
+  shared: "true"
+provisioner: kubernetes.io/portworx-volume
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+---
+# Streams
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: portworx-shared-gp-allow
+  labels:
+    {{- include "ibm-portworx.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    helm.sh/hook-weight: "-1"
+parameters:
+  priority_io: high
+  repl: "3"
+  io_profile: "cms"
+provisioner: kubernetes.io/portworx-volume
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+---
+#  General Purpose, 1 Replica - RWX volumes for TESTING ONLY.
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: portworx-rwx-gp-sc
+  labels:
+    {{- include "ibm-portworx.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    helm.sh/hook-weight: "-1"
+provisioner: kubernetes.io/portworx-volume
+parameters:
+  repl: "1"
+  priority_io: "high"
+  sharedv4: "true"
+  io_profile: db_remote
+  disable_io_profile_protection: "1"
+allowVolumeExpansion: true
+volumeBindingMode: Immediate
+reclaimPolicy: Delete
+---
+# General Purpose, 3 Replicas - RWX volumes - placeholder SC portworx-shared-gp for upgrade purposes
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: portworx-shared-gp
+  labels:
+    {{- include "ibm-portworx.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    helm.sh/hook-weight: "-1"
+parameters:
+  priority_io: high
+  repl: "3"
+  sharedv4: "true"
+  io_profile: db_remote
+  disable_io_profile_protection: "1"
+allowVolumeExpansion: true
+provisioner: kubernetes.io/portworx-volume
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+---
+# General Purpose, 3 Replicas RWO volumes rabbitmq and redis-ha - New Install
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: portworx-gp3-sc
+  labels:
+    {{- include "ibm-portworx.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    helm.sh/hook-weight: "-1"
+parameters:
+  priority_io: high
+  repl: "3"
+  io_profile: "db_remote"
+  disable_io_profile_protection: "1"
+allowVolumeExpansion: true
+provisioner: kubernetes.io/portworx-volume
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+---
+# General Purpose, 3 Replicas RWO volumes rabbitmq and redis-ha - placeholder SC portworx-nonshared-gp2 for upgrade purposes
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: portworx-nonshared-gp2
+  labels:
+    {{- include "ibm-portworx.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    helm.sh/hook-weight: "-1"
+parameters:
+  priority_io: high
+  repl: "3"
+  io_profile: "db_remote"
+  disable_io_profile_protection: "1"
+allowVolumeExpansion: true
+provisioner: kubernetes.io/portworx-volume
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+---
+#Shared gp high iops:
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: portworx-shared-gp1
+  labels:
+    {{- include "ibm-portworx.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    helm.sh/hook-weight: "-1"
+parameters:
+  priority_io: high
+  repl: "1"
+  sharedv4: "true"
+allowVolumeExpansion: true
+provisioner: kubernetes.io/portworx-volume
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+---
+# gp db
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: portworx-db-gp
+  labels:
+    {{- include "ibm-portworx.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    helm.sh/hook-weight: "-1"
+parameters:
+  io_profile: "db_remote"
+  repl: "1"
+  disable_io_profile_protection: "1"
+allowVolumeExpansion: true
+provisioner: kubernetes.io/portworx-volume
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+---
+# General Purpose for Databases, 2 Replicas - MongoDB - (Implemented application-level redundancy)
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: portworx-db-gp2-sc
+  labels:
+    {{- include "ibm-portworx.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    helm.sh/hook-weight: "-1"
+parameters:
+  priority_io: "high"
+  io_profile: "db_remote"
+  repl: "2"
+  disable_io_profile_protection: "1"
+allowVolumeExpansion: true
+provisioner: kubernetes.io/portworx-volume
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+---
+# General Purpose for Databases, 3 Replicas
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: portworx-db-gp3-sc
+  labels:
+    {{- include "ibm-portworx.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    helm.sh/hook-weight: "-1"
+parameters:
+  io_profile: "db_remote"
+  repl: "3"
+  priority_io: "high"
+  disable_io_profile_protection: "1"
+allowVolumeExpansion: true
+provisioner: kubernetes.io/portworx-volume
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+---
+# DB2 RWX shared volumes for System Storage, backup storage, future load storage, and future diagnostic logs storage
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: portworx-db2-rwx-sc
+  labels:
+    {{- include "ibm-portworx.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    helm.sh/hook-weight: "-1"
+parameters:
+  io_profile: cms
+  block_size: 4096b
+  nfs_v4: "true"
+  repl: "3"
+  sharedv4: "true"
+  priority_io: high
+provisioner: kubernetes.io/portworx-volume
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+---
+# Db2 RWO volumes SC for user storage, future transaction logs storage, future archive/mirrors logs storage. This is also used for WKC DB2 Metastore
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: portworx-db2-rwo-sc
+  labels:
+    {{- include "ibm-portworx.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    helm.sh/hook-weight: "-1"
+parameters:
+  block_size: 4096b
+  io_profile: db_remote
+  priority_io: high
+  repl: "3"
+  sharedv4: "false"
+  disable_io_profile_protection: "1"
+provisioner: kubernetes.io/portworx-volume
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+---
+# WKC DB2 Metastore - SC portworx-db2-sc for upgrade purposes
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: portworx-db2-sc
+  labels:
+    {{- include "ibm-portworx.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    helm.sh/hook-weight: "-1"
+parameters:
+  io_profile: "db_remote"
+  priority_io: high
+  repl: "3"
+  disable_io_profile_protection: "1"
+provisioner: kubernetes.io/portworx-volume
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+---
+# Watson Assistant - This was previously named portworx-assistant
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: portworx-watson-assistant-sc
+  labels:
+    {{- include "ibm-portworx.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    helm.sh/hook-weight: "-1"
+parameters:
+  repl: "3"
+  priority_io: "high"
+  io_profile: "db_remote"
+  block_size: "64k"
+  disable_io_profile_protection: "1"
+allowVolumeExpansion: true
+provisioner: kubernetes.io/portworx-volume
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+---
+# FCI DB2 Metastore
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: portworx-db2-fci-sc
+  labels:
+    {{- include "ibm-portworx.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    helm.sh/hook-weight: "-1"
+provisioner: kubernetes.io/portworx-volume
+allowVolumeExpansion: true
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+parameters:
+  block_size: 512b
+  io_profile: db_remote
+  priority_io: high
+  repl: "3"
+  disable_io_profile_protection: "1"


### PR DESCRIPTION
- Adds storage classes to the chart
- Changes the sync-wave to -1 for the portworx service and the storage classes

cloud-native-toolkit/terraform-gitops-ibm-portworx#4

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>