### PR TITLE
ibm-portworx: v0.4.0

### DIFF
--- a/stable/ibm-portworx/Chart.yaml
+++ b/stable/ibm-portworx/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/ibm-portworx/templates/_helpers.tpl
+++ b/stable/ibm-portworx/templates/_helpers.tpl
@@ -78,5 +78,13 @@ Create the name of the service account to use
 {{- end }}
 
 {{- define "ibm-portworx.service-name" }}
-{{- "portworx" }}
+{{- include "ibm-portworx.fullname" . }}
+{{- end }}
+
+{{- define "ibm-portworx.namespace" }}
+{{- if eq .Release.Namespace "kube-system" }}
+{{- .Release.Namespace }}
+{{- else }}
+{{- required "The chart must be installed kube-system namespace" "" }}
+{{- end }}
 {{- end }}

--- a/stable/ibm-portworx/templates/configmap.yaml
+++ b/stable/ibm-portworx/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "ibm-portworx.fullname" . }}
+  namespace: {{ include "ibm-portworx.namespace" . }}
   annotations:
     argocd.argoproj.io/sync-wave: "-5"
     helm.sh/hook-weight: "-5"

--- a/stable/ibm-portworx/templates/daemonset.yaml
+++ b/stable/ibm-portworx/templates/daemonset.yaml
@@ -1,7 +1,8 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: {{ include "ibm-portworx.name" . }}
+  name: {{ include "ibm-portworx.fullname" . }}
+  namespace: {{ include "ibm-portworx.namespace" . }}
   labels:
     {{- include "ibm-portworx.labels" . | nindent 4 }}
   annotations:

--- a/stable/ibm-portworx/templates/job.yaml
+++ b/stable/ibm-portworx/templates/job.yaml
@@ -2,6 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ printf "%s-job" (include "ibm-portworx.fullname" .) }}
+  namespace: {{ include "ibm-portworx.namespace" . }}
   labels:
     {{- include "ibm-portworx.labels" . | nindent 4}}
   annotations:

--- a/stable/ibm-portworx/templates/operator-configmap.yaml
+++ b/stable/ibm-portworx/templates/operator-configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "ibm-portworx.operator-config" . }}
+  namespace: {{ include "ibm-portworx.namespace" . }}
   labels:
     {{- include "ibm-portworx.labels" . | nindent 4 }}
   annotations:

--- a/stable/ibm-portworx/templates/operator-secret.yaml
+++ b/stable/ibm-portworx/templates/operator-secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "ibm-portworx.operator-secret" . }}
+  namespace: {{ include "ibm-portworx.namespace" . }}
   labels:
     {{- include "ibm-portworx.labels" . | nindent 4 }}
   annotations:

--- a/stable/ibm-portworx/templates/portworx-service.yaml
+++ b/stable/ibm-portworx/templates/portworx-service.yaml
@@ -2,6 +2,7 @@ apiVersion: ibmcloud.ibm.com/v1
 kind: Service
 metadata:
   name: {{ include "ibm-portworx.service-name" . }}
+  namespace: {{ include "ibm-portworx.namespace" . }}
   labels:
     {{- include "ibm-portworx.labels" . | nindent 4 }}
   annotations:

--- a/stable/ibm-portworx/templates/post-delete-hook-config.yaml
+++ b/stable/ibm-portworx/templates/post-delete-hook-config.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ printf "%s-delete" (include "ibm-portworx.fullname" .) }}
+  namespace: {{ include "ibm-portworx.namespace" . }}
   annotations:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "-1"

--- a/stable/ibm-portworx/templates/post-delete-hook.yaml
+++ b/stable/ibm-portworx/templates/post-delete-hook.yaml
@@ -2,6 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ printf "%s-delete" (include "ibm-portworx.fullname" .) }}
+  namespace: {{ include "ibm-portworx.namespace" . }}
   labels:
     {{- include "ibm-portworx.labels" . | nindent 4 }}
   annotations:
@@ -39,6 +40,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ printf "%s-delete" (include "ibm-portworx.serviceAccountName" .) }}
+  namespace: {{ include "ibm-portworx.namespace" . }}
   labels:
     {{- include "ibm-portworx.labels" . | nindent 4 }}
   annotations:
@@ -50,6 +52,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ printf "%s-delete" (include "ibm-portworx.fullname" .) }}
+  namespace: {{ include "ibm-portworx.namespace" . }}
   labels:
   {{- include "ibm-portworx.labels" . | nindent 4 }}
   annotations:
@@ -109,6 +112,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ printf "%s-delete" (include "ibm-portworx.fullname" .) }}
+  namespace: {{ include "ibm-portworx.namespace" . }}
   annotations:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "-1"

--- a/stable/ibm-portworx/templates/rbac.yaml
+++ b/stable/ibm-portworx/templates/rbac.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "ibm-portworx.fullname" . }}
+  namespace: {{ include "ibm-portworx.namespace" . }}
   labels:
   {{- include "ibm-portworx.labels" . | nindent 4 }}
   annotations:
@@ -33,7 +34,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "ibm-portworx.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ibm-portworx.namespace" . }}
   annotations:
     argocd.argoproj.io/sync-wave: "-5"
     helm.sh/hook-weight: "-5"
@@ -58,7 +59,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "ibm-portworx.fullname" . }}
-  annotations:
+  namespace: {{ include "ibm-portworx.namespace" . }}
+ annotations:
     argocd.argoproj.io/sync-wave: "-5"
     helm.sh/hook-weight: "-5"
   labels:
@@ -70,13 +72,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "ibm-portworx.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "ibm-portworx.namespace" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "ibm-portworx.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ibm-portworx.namespace" . }}
   annotations:
     argocd.argoproj.io/sync-wave: "-5"
     helm.sh/hook-weight: "-5"
@@ -89,5 +91,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "ibm-portworx.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "ibm-portworx.namespace" . }}
 {{- end -}}

--- a/stable/ibm-portworx/templates/serviceaccount.yaml
+++ b/stable/ibm-portworx/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "ibm-portworx.serviceAccountName" . }}
+  namespace: {{ include "ibm-portworx.namespace" . }}
   labels:
     {{- include "ibm-portworx.labels" . | nindent 4 }}
   annotations:


### PR DESCRIPTION
Updates the chart to deploy only to kube-system namespace

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>