### PR TITLE
openshift-gitops-instance: v0.5.1

### DIFF
--- a/stable/openshift-gitops-instance/Chart.yaml
+++ b/stable/openshift-gitops-instance/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.5.0
+version: 0.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.16.0
+appVersion: 1.22.9

--- a/stable/openshift-gitops-instance/templates/_helpers.tpl
+++ b/stable/openshift-gitops-instance/templates/_helpers.tpl
@@ -63,5 +63,9 @@ Create the name of the service account to use
 {{- end -}}
 
 {{- define "openshift-gitops-instance.argocd-name" -}}
-{{ "argocd-cluster" }}
+{{- if eq .Release.Namespace "openshift-gitops" }}
+{{- .Release.Namespace }}
+{{- else }}
+{{- printf "%s-gitops" .Release.Namespace }}
+{{- end }}
 {{- end -}}

--- a/stable/openshift-gitops-instance/templates/instance-config-map.yaml
+++ b/stable/openshift-gitops-instance/templates/instance-config-map.yaml
@@ -20,10 +20,7 @@ data:
     spec:
       {{- .Values.openshiftgitops.argocd.spec | toYaml | nindent 6 }}
   apply.sh: |
-    NAMESPACE="$1"
-    INSTANCE_NAME="$2"
-    CONFIG_FILE="$3"
-    PATCH_FILE="$4"
+    #!/bin/bash
 
     if oc get argocd $INSTANCE_NAME -n $NAMESPACE 1> /dev/null 2> /dev/null; then
       kubectl patch argocd $INSTANCE_NAME -n $NAMESPACE --type merge -p "$(cat $PATCH_FILE)"

--- a/stable/openshift-gitops-instance/templates/instance-job.yaml
+++ b/stable/openshift-gitops-instance/templates/instance-job.yaml
@@ -18,6 +18,7 @@ metadata:
     "helm.sh/hook": post-install
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:
+  ttlSecondsAfterFinished: 300
   template:
     metadata:
       name: job-{{ include "openshift-gitops-instance.name" . }}
@@ -33,7 +34,7 @@ spec:
             defaultMode: 0777
       containers:
         - name: create-instance
-          image: "docker.io/bitnami/kubectl:latest"
+          image: {{ printf "docker.io/bitnami/kubectl:%s" .Chart.AppVersion }}
           volumeMounts:
             - mountPath: /config
               name: config-yaml
@@ -42,7 +43,10 @@ spec:
               value: openshift-gitops
             - name: INSTANCE_NAME
               value: {{ include "openshift-gitops-instance.argocd-name" . }}
-          command: ["/bin/sh", "-c"]
-          args:
-            - /config/apply.sh $NAMESPACE $INSTANCE_NAME /config/instance.yaml /config/patch.yaml
+            - name: CONFIG_FILE
+              value: /config/instance.yaml
+            - name: PATCH_FILE
+              value: /config/patch.yaml
+          command:
+            - /config/apply.sh
 {{- end -}}

--- a/stable/openshift-gitops-instance/values.yaml
+++ b/stable/openshift-gitops-instance/values.yaml
@@ -6,7 +6,6 @@ controllerRbac: true
 
 openshiftgitops:
   argocd:
-    name: openshift-gitops-cntk
     spec:
       server:
         autoscale:


### PR DESCRIPTION
- Updates logic to build the openshift-gitops instance name to prevent two instances in the same namespace
- Adds ttlSecondsAfterFinish to 300 (5 minutes) to remove the job after deployment

cloud-native-toolkit/software-everywhere#169

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>