### PR TITLE
openshift-gitops-instance: v0.5.2

### DIFF
--- a/stable/openshift-gitops-instance/Chart.yaml
+++ b/stable/openshift-gitops-instance/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.5.1
+version: 0.5.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/stable/openshift-gitops-instance/templates/_helpers.tpl
+++ b/stable/openshift-gitops-instance/templates/_helpers.tpl
@@ -40,6 +40,9 @@ helm.sh/chart: {{ include "openshift-gitops-instance.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
+{{- if .Values.createdBy }}
+created-by: {{ .Values.createdBy | quote }}
+{{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 

--- a/stable/openshift-gitops-instance/templates/instance-config-map.yaml
+++ b/stable/openshift-gitops-instance/templates/instance-config-map.yaml
@@ -14,6 +14,8 @@ data:
     kind: ArgoCD
     metadata:
       name: {{ include "openshift-gitops-instance.argocd-name" . }}
+      labels:
+        {{- include "openshift-gitops-instance.labels" . | nindent 8 }}
     spec:
       {{- .Values.openshiftgitops.argocd.spec | toYaml | nindent 6 }}
   patch.yaml: |

--- a/stable/openshift-gitops-instance/templates/instance.yaml
+++ b/stable/openshift-gitops-instance/templates/instance.yaml
@@ -4,6 +4,8 @@ kind: ArgoCD
 metadata:
   name: {{ .Values.openshiftgitops.argocd.name }}
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openshift-gitops-instance.labels" . | nindent 4 }}
 spec:
   {{- toYaml .Values.openshiftgitops.argocd.spec | nindent 2 }}
 {{- end }}

--- a/stable/openshift-gitops-instance/values.yaml
+++ b/stable/openshift-gitops-instance/values.yaml
@@ -114,3 +114,5 @@ openshiftgitops:
           requests:
             cpu: 250m
             memory: 1Gi    
+
+createdBy: ""


### PR DESCRIPTION
Adds optional created-by label via createdBy value - cloud-native-toolkit/terraform-tools-argocd#72

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>