### PR TITLE
openshift-gitops-instance: v0.5.3

### DIFF
--- a/stable/openshift-gitops-instance/Chart.yaml
+++ b/stable/openshift-gitops-instance/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.5.2
+version: 0.5.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/stable/openshift-gitops-instance/templates/instance.yaml
+++ b/stable/openshift-gitops-instance/templates/instance.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: ArgoCD
 metadata:
-  name: {{ .Values.openshiftgitops.argocd.name }}
+  name: {{ include "openshift-gitops-instance.argocd-name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "openshift-gitops-instance.labels" . | nindent 4 }}

--- a/stable/openshift-gitops-instance/templates/rbac.yaml
+++ b/stable/openshift-gitops-instance/templates/rbac.yaml
@@ -6,7 +6,7 @@ kind: ClusterRole
 metadata:
   name: {{ $name }}
   labels:
-    {{ include "openshift-gitops-instance.labels" . | nindent 4 }}
+    {{- include "openshift-gitops-instance.labels" . | nindent 4 }}
 rules:
 - apiGroups:
   - "*"
@@ -20,7 +20,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ $name }}
   labels:
-    {{ include "openshift-gitops-instance.labels" . | nindent 4 }}
+    {{- include "openshift-gitops-instance.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
Fixes name in argocd instance and empty spaces in rbac roles

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>