### PR TITLE
tekton-operator: v0.3.0

### DIFF
--- a/stable/tekton-operator/Chart.yaml
+++ b/stable/tekton-operator/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.1
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/stable/tekton-operator/templates/post-install-hook.yaml
+++ b/stable/tekton-operator/templates/post-install-hook.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tekton-webhook-test
+  labels:
+    {{- include "operator.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: tekton-webhook-test
+  labels:
+    {{- include "operator.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  ttlSecondsAfterFinished: 300
+  template:
+    spec:
+      serviceAccountName: tekton-webhook-test
+      initContainers:
+        - name: wait-for-tekton-webhook
+          image: quay.io/ibmgaragecloud/alpine-curl
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: URL
+              value: {{ printf "http://tekton-pipelines-webhook.%s.svc:8080" .Values.tektonNamespace }}
+          command: ["sh"]
+          args:
+            - "-c"
+            - "count=0; until curl -Iskf ${URL} || [[ $count -eq 20 ]]; do echo \">>> waiting for ${URL}\"; sleep 90; count=$((count + 1)); done; if [[ $count -eq 20 ]]; then echo \"Timeout\"; exit 1; else echo \">>> Started\"; fi"
+      containers:
+        - name: tekton-webhook-started
+          image: quay.io/ibmgaragecloud/alpine-curl
+          imagePullPolicy: Always
+          env:
+            - name: URL
+              value: {{ printf "http://tekton-pipelines-webhook.%s.svc:8080" .Values.tektonNamespace }}
+          command: ["sh"]
+          args:
+            - "-c"
+            - "curl -Iskf ${URL}"
+      restartPolicy: Never
+  backoffLimit: 1

--- a/stable/tekton-operator/values.yaml
+++ b/stable/tekton-operator/values.yaml
@@ -23,3 +23,5 @@ operatorHub:
   name: ""
 
 createdBy: ""
+
+tektonNamespace: "openshift-pipelines"


### PR DESCRIPTION
- Adds service account and job as post-install hooks to verify the tekton webhook has started

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>