### PR TITLE
openshift-gitops-instance: v0.5.4

### DIFF
--- a/stable/openshift-gitops-instance/Chart.yaml
+++ b/stable/openshift-gitops-instance/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.5.3
+version: 0.5.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/stable/openshift-gitops-instance/templates/rbac.yaml
+++ b/stable/openshift-gitops-instance/templates/rbac.yaml
@@ -7,6 +7,9 @@ metadata:
   name: {{ $name }}
   labels:
     {{- include "openshift-gitops-instance.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": before-hook-creation
 rules:
 - apiGroups:
   - "*"
@@ -21,6 +24,9 @@ metadata:
   name: {{ $name }}
   labels:
     {{- include "openshift-gitops-instance.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": before-hook-creation
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
- Addresses timing issue for ArgoCD deletions by marking RBAC resources as pre-install hooks

cloud-native-toolkit/terraform-tools-argocd#89

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>