### PR TITLE
ibm-portworx: v0.5.0

### DIFF
--- a/stable/ibm-portworx/Chart.yaml
+++ b/stable/ibm-portworx/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.3
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/ibm-portworx/templates/configmap.yaml
+++ b/stable/ibm-portworx/templates/configmap.yaml
@@ -280,6 +280,10 @@ data:
     ZONE=$(echo "${NODE_JSON}" | jq -r '.metadata.labels["ibm-cloud.kubernetes.io/zone"]')
     WORKER_ID=$(echo "${NODE_JSON}" | jq -r '.metadata.labels["ibm-cloud.kubernetes.io/worker-id"]')
 
+    CLUSTER_ID=$(echo "${NODE_JSON}" | jq -r '.spec.providerID' | sed -E 's~.*/([^/]+)/[^/]+~\1~g')
+
+    CLUSTER_ID
+
     echo "Node values: region=${REGION}, zone=${ZONE}, workerId=${WORKER_ID}"
 
     NAME="pwx-${WORKER_ID}"
@@ -300,6 +304,11 @@ data:
       echo "ENCRYPTION_KEY environment variable not provided. The volume won't be encrypted with KMS."
     fi
 
+    TAGS=$(jq -n \
+      --arg CLUSTER_ID "${CLUSTER_ID}" \
+      --arg WORKER_ID "${WORKER_ID}" \
+      '["clusterid:$CLUSTER_ID", "workerid:$WORKER_ID", "source:portworx"]')
+
     jq -n \
       --arg NAME "${NAME}" \
       --arg ZONE "${ZONE}" \
@@ -307,7 +316,9 @@ data:
       --argjson IOPS "${IOPS}" \
       --argjson CAPACITY "${CAPACITY}" \
       --arg PROFILE "${PROFILE}" \
-      '{"name": $NAME, "iops": $IOPS, "capacity": $CAPACITY, "zone": {"name": $ZONE}, "profile": {"name": $PROFILE}, "resource_group": {"id": $RESOURCE_GROUP_ID}}' > /tmp/volume-request.json
+      --argjson TAGS "${TAGS}" \
+      '{"name": $NAME, "iops": $IOPS, "capacity": $CAPACITY, "zone": {"name": $ZONE}, "profile": {"name": $PROFILE}, "resource_group": {"id": $RESOURCE_GROUP_ID}, "user_tags": $TAGS}' \
+      > /tmp/volume-request.json
 
     if [[ -n "${ENCRYPTION_KEY}" ]]; then
       cat /tmp/volume-request.json | jq --arg ENCRYPTION_KEY "${ENCRYPTION_KEY}" \


### PR DESCRIPTION
- Adds clusterid, workerid, and storage tags to the created volumes

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>