### PR TITLE
ibm-portworx: v0.6.0

### DIFF
--- a/stable/ibm-portworx/Chart.yaml
+++ b/stable/ibm-portworx/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/ibm-portworx/templates/daemonset.yaml
+++ b/stable/ibm-portworx/templates/daemonset.yaml
@@ -42,6 +42,14 @@ spec:
                 secretKeyRef:
                   name: {{ include "ibm-portworx.operator-secret" . }}
                   key: api-key
+            - name: IOPS
+              value: {{ .Values.volume.iops | quote }}
+            - name: CAPACITY
+              value: {{ .Values.volume.capacity | quote }}
+            - name: PROFILE
+              value: {{ .Values.volume.profile | quote }}
+            - name: ENCRYPTION_KEY
+              value: {{ .Values.volume.encryption_key | quote }}
           command:
             - /bin/sh
           args:

--- a/stable/ibm-portworx/values.yaml
+++ b/stable/ibm-portworx/values.yaml
@@ -32,3 +32,9 @@ region: ""
 
 plan: px-enterprise
 etcdSecretName: ""
+
+volume:
+  iops: 100
+  capacity: 50
+  profile: custom
+  encryption_key: ""


### PR DESCRIPTION
- Exposes values for IOPS, CAPACITY, PROFILE, and ENCRYPTION_KEY

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>