### PR TITLE
ibm-portworx: v0.6.1

### DIFF
--- a/stable/ibm-portworx/Chart.yaml
+++ b/stable/ibm-portworx/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/ibm-portworx/values.yaml
+++ b/stable/ibm-portworx/values.yaml
@@ -34,7 +34,7 @@ plan: px-enterprise
 etcdSecretName: ""
 
 volume:
-  iops: 100
-  capacity: 50
-  profile: custom
+  iops: 3000
+  capacity: 200
+  profile: 10iops-tier
   encryption_key: ""


### PR DESCRIPTION
- Updates default values for volume variables (iops:3000, capacity:200, profile:10iops-tier)

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>