### PR TITLE
ocp-service-tls: v0.1.0

### DIFF
--- a/stable/ocp-service-tls/.helmignore
+++ b/stable/ocp-service-tls/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/stable/ocp-service-tls/Chart.yaml
+++ b/stable/ocp-service-tls/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: ocp-service-tls
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 1.16.0

--- a/stable/ocp-service-tls/scripts/_update-configmap.sh
+++ b/stable/ocp-service-tls/scripts/_update-configmap.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
+SUPPORT_DIR=$(cd "${SCRIPT_DIR}/../support"; pwd -P)
+TEMPLATE_DIR=$(cd "${SCRIPT_DIR}/../templates"; pwd -P)
+
+if ! command -v oc 1> /dev/null 2> /dev/null; then
+  echo "oc cli required" >&2
+  exit 1
+fi
+
+if ! command -v yq 1> /dev/null 2> /dev/null; then
+  echo "yq cli required" >&2
+  exit 1
+fi
+
+cat "${SUPPORT_DIR}/configmap.snippet.yaml" > "${TEMPLATE_DIR}/configmap.yaml"
+
+oc create configmap tmp \
+  --from-file=${SCRIPT_DIR}/annotate-service.sh \
+  --from-file=${SCRIPT_DIR}/wait-for-service.sh \
+  --dry-run=client \
+  -o yaml | \
+yq eval 'del(.apiVersion) | del(.kind) | del(.metadata)' - >> "${TEMPLATE_DIR}/configmap.yaml"

--- a/stable/ocp-service-tls/scripts/annotate-service.sh
+++ b/stable/ocp-service-tls/scripts/annotate-service.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+if [[ -z "${SERVICE}" ]] || [[ -z "${NAMESPACE}" ]] || [[ -z "${SECRET_NAME}" ]]; then
+  echo "SERVICE, NAMESPACE and SECRET_NAME are required environment variables" >&2
+  exit 1
+fi
+
+if ! command -v oc 1> /dev/null 2> /dev/null; then
+  echo "oc cli not found" >&2
+  exit 1
+fi
+
+echo "Adding annotation to service (${SERVICE}): service.beta.openshift.io/serving-cert-secret-name=${SECRET_NAME}"
+oc annotate service "${SERVICE}" -n "${NAMESPACE}" --overwrite=true \
+     "service.beta.openshift.io/serving-cert-secret-name=${SECRET_NAME}"
+
+if [[ -z "${CA_CONFIG_MAP_NAME}" ]]; then
+  echo "No configmap configuration provided. Exiting..."
+  exit 0
+fi
+
+echo "Creating configmap for ca certificate: ${CA_CONFIG_MAP_NAME}"
+oc create configmap "${CA_CONFIG_MAP_NAME}" -n "${NAMESPACE}" --dry-run=client --output=json --from-literal=test=replaceme | \
+  oc annotate -f - service.beta.openshift.io/inject-cabundle=true --local=true --dry-run=client --output=json | \
+  oc apply -f -

--- a/stable/ocp-service-tls/scripts/wait-for-service.sh
+++ b/stable/ocp-service-tls/scripts/wait-for-service.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+if [[ -z "${SERVICE}" ]] || [[ -z "${NAMESPACE}" ]]; then
+  echo "SERVICE and NAMESPACE are required environment variables" >&2
+  exit 1
+fi
+
+if ! command -v oc 1> /dev/null 2> /dev/null; then
+  echo "oc cli not found" >&2
+  exit 1
+fi
+
+count=0
+echo "Waiting for service: ${SERVICE}"
+until oc get service "${SERVICE}" -n "${NAMESPACE}" 1> /dev/null 2> /dev/null || [[ "${count}" -eq 20 ]]; do
+  count$((count + 1))
+  sleep 30
+done
+
+if [[ "${count}" -eq 20 ]]; then
+  echo "Timed out waiting for service: ${SERVICE}" >&2
+  exit 1
+fi
+
+echo "*** The service has been created"

--- a/stable/ocp-service-tls/support/configmap.snippet.yaml
+++ b/stable/ocp-service-tls/support/configmap.snippet.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "ocp-service-tls.name" . }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ .Values.syncWave | quote }}
+  labels:
+  {{ include "ocp-service-tls.labels" . | nindent 4 }}

--- a/stable/ocp-service-tls/templates/_helpers.tpl
+++ b/stable/ocp-service-tls/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ocp-service-tls.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "ocp-service-tls.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ocp-service-tls.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "ocp-service-tls.labels" -}}
+helm.sh/chart: {{ include "ocp-service-tls.chart" . }}
+{{ include "ocp-service-tls.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "ocp-service-tls.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ocp-service-tls.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "ocp-service-tls.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "ocp-service-tls.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/stable/ocp-service-tls/templates/configmap.yaml
+++ b/stable/ocp-service-tls/templates/configmap.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "ocp-service-tls.name" . }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ .Values.syncWave | quote }}
+  labels:
+  {{ include "ocp-service-tls.labels" . | nindent 4 }}
+data:
+  annotate-service.sh: |
+    #!/usr/bin/env bash
+
+    if [[ -z "${SERVICE}" ]] || [[ -z "${NAMESPACE}" ]] || [[ -z "${SECRET_NAME}" ]]; then
+      echo "SERVICE, NAMESPACE and SECRET_NAME are required environment variables" >&2
+      exit 1
+    fi
+
+    if ! command -v oc 1> /dev/null 2> /dev/null; then
+      echo "oc cli not found" >&2
+      exit 1
+    fi
+
+    echo "Adding annotation to service (${SERVICE}): service.beta.openshift.io/serving-cert-secret-name=${SECRET_NAME}"
+    oc annotate service "${SERVICE}" -n "${NAMESPACE}" --overwrite=true \
+         "service.beta.openshift.io/serving-cert-secret-name=${SECRET_NAME}"
+
+    if [[ -z "${CA_CONFIG_MAP_NAME}" ]]; then
+      echo "No configmap configuration provided. Exiting..."
+      exit 0
+    fi
+
+    echo "Creating configmap for ca certificate: ${CA_CONFIG_MAP_NAME}"
+    oc create configmap "${CA_CONFIG_MAP_NAME}" -n "${NAMESPACE}" --dry-run=client --output=json --from-literal=test=replaceme | \
+      oc annotate -f - service.beta.openshift.io/inject-cabundle=true --local=true --dry-run=client --output=json | \
+      oc apply -f -
+  wait-for-service.sh: |
+    #!/usr/bin/env bash
+
+    if [[ -z "${SERVICE}" ]] || [[ -z "${NAMESPACE}" ]]; then
+      echo "SERVICE and NAMESPACE are required environment variables" >&2
+      exit 1
+    fi
+
+    if ! command -v oc 1> /dev/null 2> /dev/null; then
+      echo "oc cli not found" >&2
+      exit 1
+    fi
+
+    count=0
+    echo "Waiting for service: ${SERVICE}"
+    until oc get service "${SERVICE}" -n "${NAMESPACE}" 1> /dev/null 2> /dev/null || [[ "${count}" -eq 20 ]]; do
+      count$((count + 1))
+      sleep 30
+    done
+
+    if [[ "${count}" -eq 20 ]]; then
+      echo "Timed out waiting for service: ${SERVICE}" >&2
+      exit 1
+    fi
+
+    echo "*** The service has been created"

--- a/stable/ocp-service-tls/templates/job.yaml
+++ b/stable/ocp-service-tls/templates/job.yaml
@@ -1,0 +1,55 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "ocp-service-tls.name" . }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    argocd.argoproj.io/sync-wave: {{ .Values.syncWave | quote }}
+  labels:
+{{ include "ocp-service-tls.labels" . | nindent 4 }}
+spec:
+  template:
+    spec:
+      serviceAccountName: {{ required "The service account name is required" .Values.serviceAccount.name }}
+      volumes:
+        - name: scripts
+          configMap:
+            name: {{ include "ocp-service-tls.name" . }}
+            defaultMode: 0777
+      initContainers:
+        - name: wait-for-service
+          image: {{ printf "%s:%s" .Values.job.repository .Values.job.tag }}
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: SERVICE
+              value: {{ .Values.serviceName }}
+          command: ["/opt/bin/wait-for-service.sh"]
+          volumeMounts:
+            - mountPath: /opt/bin
+              name: scripts
+      containers:
+        - name: annotate-service
+          image: {{ printf "%s:%s" .Values.job.repository .Values.job.tag }}
+          command: ["/opt/bin/create-secret.sh"]
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: SERVICE
+              value: {{ .Values.serviceName }}
+            - name: SECRET_NAME
+              value: {{ required "The secretName is required" .Values.secretName }}
+            {{- if .Values.caConfigName }}
+            - name: CA_CONFIG_MAP_NAME
+              value: {{ .Values.caConfigName }}
+            {{- end }}
+          volumeMounts:
+            - mountPath: /opt/bin
+              name: scripts
+      restartPolicy: Never
+  backoffLimit: 4

--- a/stable/ocp-service-tls/templates/rbac.yaml
+++ b/stable/ocp-service-tls/templates/rbac.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.serviceAccount.rbac -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Values.serviceAccount.name }}-rbac
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ .Values.syncWave | quote }}
+  labels:
+{{ include "ocp-service-tls.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["services", "configmaps"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.serviceAccount.name }}-rbac
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ .Values.syncWave | quote }}
+  labels:
+{{ include "ocp-service-tls.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ .Values.serviceAccount.name }}-rbac
+  apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/stable/ocp-service-tls/templates/serviceaccount.yaml
+++ b/stable/ocp-service-tls/templates/serviceaccount.yaml
@@ -7,5 +7,5 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: {{ .Values.syncWave | quote }}
   labels:
-{{ include "ocp-service-tls.labels" . | nindent 4 }}
+    {{ include "ocp-service-tls.labels" . | nindent 4 }}
 {{- end -}}

--- a/stable/ocp-service-tls/templates/serviceaccount.yaml
+++ b/stable/ocp-service-tls/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ .Values.syncWave | quote }}
+  labels:
+{{ include "ocp-service-tls.labels" . | nindent 4 }}
+{{- end -}}

--- a/stable/ocp-service-tls/values.yaml
+++ b/stable/ocp-service-tls/values.yaml
@@ -1,0 +1,19 @@
+# Default values for ocp-service-tls.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+job:
+  repository: ibmgaragecloud/ibmcloud-dev
+  tag: 1.2.2
+  autoApproveCsr: true
+
+serviceAccount:
+  name: job-service-annotation
+  create: true
+  rbac: true
+
+serviceName: ""
+secretName: ""
+caConfigName: ""
+
+syncWave: "-3"


### PR DESCRIPTION
Adds chart to create a job that will add service.beta.openshift.io/serving-cert-secret-name annotation to existing Service and optionally create config map with service.beta.openshift.io/inject-cabundle=true annotation

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>