### PR TITLE
ocp-service-tls: v0.2.1

### DIFF
--- a/stable/ocp-service-tls/Chart.yaml
+++ b/stable/ocp-service-tls/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/ocp-service-tls/scripts/wait-for-service.sh
+++ b/stable/ocp-service-tls/scripts/wait-for-service.sh
@@ -13,7 +13,7 @@ fi
 count=0
 echo "Waiting for service: ${SERVICE}"
 until oc get service "${SERVICE}" -n "${NAMESPACE}" 1> /dev/null 2> /dev/null || [[ "${count}" -eq 20 ]]; do
-  count$((count + 1))
+  count=$((count + 1))
   sleep 30
 done
 
@@ -22,4 +22,4 @@ if [[ "${count}" -eq 20 ]]; then
   exit 1
 fi
 
-echo "*** The service has been created"
+echo "*** The service has been created: ${SERVICE}"

--- a/stable/ocp-service-tls/templates/configmap.yaml
+++ b/stable/ocp-service-tls/templates/configmap.yaml
@@ -50,7 +50,7 @@ data:
     count=0
     echo "Waiting for service: ${SERVICE}"
     until oc get service "${SERVICE}" -n "${NAMESPACE}" 1> /dev/null 2> /dev/null || [[ "${count}" -eq 20 ]]; do
-      count$((count + 1))
+      count=$((count + 1))
       sleep 30
     done
 
@@ -59,4 +59,4 @@ data:
       exit 1
     fi
 
-    echo "*** The service has been created"
+    echo "*** The service has been created: ${SERVICE}"


### PR DESCRIPTION
Fixes typo in wait-for-service.sh script

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>