### PR TITLE
tool-config: v0.14.0

### DIFF
--- a/stable/tool-config/Chart.yaml
+++ b/stable/tool-config/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart to create a ConfigMap and Secret containing the config
 
 type: application
 
-version: 0.13.0
+version: 0.14.0
 
 appVersion: "1.0"

--- a/stable/tool-config/templates/_helpers.tpl
+++ b/stable/tool-config/templates/_helpers.tpl
@@ -41,12 +41,14 @@ Expand the name of the chart.
 {{- define "tool-config.url" -}}
 {{- if .Values.url -}}
 {{ .Values.url }}
-{{- else -}}
+{{- else if (include "tool-config.ingressSubdomain" .) -}}
 {{- if .Values.includeNamespace -}}
 {{ printf "https://%s-%s.%s" .Values.host .Release.Namespace (include "tool-config.ingressSubdomain" .)}}
 {{- else -}}
 {{ printf "https://%s.%s" .Values.host (include "tool-config.ingressSubdomain" .) }}
 {{- end -}}
+{{- else -}}
+{{ "" }}
 {{- end -}}
 {{- end -}}
 

--- a/stable/tool-config/templates/config-map.yaml
+++ b/stable/tool-config/templates/config-map.yaml
@@ -1,3 +1,4 @@
+{{- if or (include "tool-config.url" .) (.Values.otherConfig | len) }}
 {{- $toolPrefix := include "tool-config.NAME" . -}}
 apiVersion: v1
 kind: ConfigMap
@@ -24,3 +25,4 @@ data:
   {{- range $key, $val := .Values.otherConfig }}
   {{ printf "%s_%s" $toolPrefix (upper $key) }}: {{ $val | quote }}
   {{- end }}
+{{- end }}


### PR DESCRIPTION
Surpresses config map creation if the public url and the otherConfig is empty

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>