### PR TITLE
rbac: v0.2.0

### DIFF
--- a/stable/rbac/Chart.yaml
+++ b/stable/rbac/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/rbac/templates/rbac.yaml
+++ b/stable/rbac/templates/rbac.yaml
@@ -1,7 +1,7 @@
 {{- if gt (len .Values.rules) 0 }}
 {{- $kind := ternary "ClusterRole" "Role" (eq .Values.clusterScope "true") }}
-{{- $serviceAccountName := required "The serviceAccount.name is required" .Values.serviceAccount.name }}
-{{- $serviceAccountNamespace := required "The serviceAccount.namespace is required" .Values.serviceAccount.namespace }}
+{{- $serviceAccountName := .Values.serviceAccount.name }}
+{{- $serviceAccountNamespace := .Values.serviceAccount.namespace | default .Release.Namespace }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ $kind }}
 metadata:
@@ -26,7 +26,13 @@ roleRef:
   kind: {{ $kind }}
   name: {{ .Release.Name }}
 subjects:
+  {{- if $serviceAccountName }}
   - kind: ServiceAccount
     name: {{ $serviceAccountName }}
     namespace: {{ $serviceAccountNamespace }}
+  {{- else }}
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: {{ printf "system:serviceaccounts:%s" $serviceAccountNamespace }}
+  {{- end }}
 {{- end }}

--- a/stable/rbac/templates/roleBindings.yaml
+++ b/stable/rbac/templates/roleBindings.yaml
@@ -1,7 +1,7 @@
 {{- $kind := ternary "ClusterRole" "Role" (eq .Values.clusterScope "true") }}
 {{- $releaseName := .Release.Name }}
-{{- $serviceAccountName := required "The serviceAccount.name is required" .Values.serviceAccount.name }}
-{{- $serviceAccountNamespace := required "The serviceAccount.namespace is required" .Values.serviceAccount.namespace }}
+{{- $serviceAccountName := .Values.serviceAccount.name }}
+{{- $serviceAccountNamespace := .Values.serviceAccount.namespace | default .Release.Namespace }}
 {{- $root := . }}
 {{- range .Values.roles }}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -17,8 +17,14 @@ roleRef:
   kind: ClusterRole
   name: {{ .name }}
 subjects:
+  {{- if $serviceAccountName }}
   - kind: ServiceAccount
     name: {{ $serviceAccountName }}
     namespace: {{ $serviceAccountNamespace }}
+  {{- else }}
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: {{ printf "system:serviceaccounts:%s" $serviceAccountNamespace }}
+  {{- end }}
 ---
 {{- end }}


### PR DESCRIPTION
Removes serviceAccount name and namespace as required fields. If the serviceAccount name is not provided then the rule defaults to granting access to group of all service accounts in the provided namespace. If the serviceAccount namespace is not provided the namespace defaults to the one provided for the chart.

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>