### PR TITLE
service-account: v1.0.1

### DIFF
--- a/stable/service-account/Chart.yaml
+++ b/stable/service-account/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/stable/service-account/templates/rbac.yaml
+++ b/stable/service-account/templates/rbac.yaml
@@ -1,6 +1,6 @@
 {{- if gt (len .Values.rules) 0 }}
 {{- $allServiceAccounts := .Values.allServiceAccounts }}
-{{- $kind := ternary "ClusterRole" "Role" (eq .Values.clusterScope "true") }}
+{{- $kind := ternary "ClusterRole" "Role" .Values.clusterScope }}
 {{- $serviceAccountName := include "service-account.name" . }}
 {{- $serviceAccountNamespace := include "service-account.namespace" . }}
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
- Fixes "incompatible types for comparison" issue with clusterScope when rbac rules provided

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>