### PR TITLE
Fixes for security warnings with >1 model

### DIFF
--- a/stable/watson-nlp/Chart.yaml
+++ b/stable/watson-nlp/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/watson-nlp/templates/deployment.yaml
+++ b/stable/watson-nlp/templates/deployment.yaml
@@ -1,4 +1,5 @@
 {{- $compName := .Values.componentName -}}
+{{- $kubeMinor := (int .Capabilities.KubeVersion.Minor) -}}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -54,9 +55,7 @@ spec:
           - name: ACCEPT_LICENSE
             value: "true"
       {{- end }}
-      {{- end }}
-      {{- end }}
-      {{- if ge (int .Capabilities.KubeVersion.Minor) 24 }}
+      {{- if ge $kubeMinor 24 }}
         securityContext:
           allowPrivilegeEscalation: false
           runAsNonRoot: true
@@ -65,6 +64,8 @@ spec:
             - ALL
           seccompProfile:
             type: RuntimeDefault
+      {{- end }}
+      {{- end }}
       {{- end }}
       containers:
       - name: watson-nlp
@@ -131,7 +132,7 @@ spec:
             command: ["/bin/grpc_health_probe", "-addr=:8085"]
             {{- end }}
           initialDelaySeconds: 20
-      {{- if ge (int .Capabilities.KubeVersion.Minor) 24 }}
+      {{- if ge $kubeMinor 24 }}
         securityContext:
           allowPrivilegeEscalation: false
           runAsNonRoot: true
@@ -141,6 +142,3 @@ spec:
           seccompProfile:
             type: RuntimeDefault
       {{- end }}
-
-
-


### PR DESCRIPTION
Moving the logic for adding security context into the range block for initContainers