### PR TITLE
argocd-instance: v0.1.2

### DIFF
--- a/stable/argocd-instance/Chart.yaml
+++ b/stable/argocd-instance/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/argocd-instance/templates/_helpers.tpl
+++ b/stable/argocd-instance/templates/_helpers.tpl
@@ -62,5 +62,9 @@ Create the name of the service account to use
 {{- end }}
 
 {{- define "argocd-instance.argocd-name" -}}
+{{- if eq .Release.Namespace "gitops" }}
+{{- printf "gitops" }}
+{{- else }}
 {{- printf "%s-gitops" .Release.Namespace }}
+{{- end }}
 {{- end -}}

--- a/stable/argocd-instance/values.yaml
+++ b/stable/argocd-instance/values.yaml
@@ -13,6 +13,7 @@ argocd:
       grpc:
         ingress:
           enabled: false
+      host: ""
       ingress:
         enabled: false
       resources:


### PR DESCRIPTION
- Updates instance name to just "gitops" if installing into "gitops" namespace (instead of "gitops-gitops")
- Adds empty host value for instance