### PR TITLE
adding specific kubernetes version ibm catalog version

### DIFF
--- a/stable/ibm-catalogs/templates/ibm-operator-catalog.yaml
+++ b/stable/ibm-catalogs/templates/ibm-operator-catalog.yaml
@@ -5,5 +5,6 @@ metadata:
   namespace: openshift-marketplace
   annotations:
     argocd.argoproj.io/sync-wave: {{ .Values.syncWave | default "-10" | quote }}
+    olm.catalogImageTemplate: "icr.io/cpopen/ibm-operator-catalog:v{kube_major_version}.{kube_minor_version}"
 spec:
   {{- toYaml .Values.catalogs.ibmoperators.catalog | nindent 2 }}


### PR DESCRIPTION
Hi @seansund and/or @hollisc, could you please look at this PR which is meant to add support for the general IBM Catalog to support OLM to deploy specific IBM Catalog version based on the exact Kubernetes Version your cluster is running as opposed to always deploy latest? This is based on what I could read at https://www.ibm.com/docs/en/cloud-paks/1.0?topic=clusters-adding-operator-catalog

Thanks