### PR TITLE
console-link-cronjob: v0.5.2

### DIFF
--- a/stable/console-link-cronjob/Chart.yaml
+++ b/stable/console-link-cronjob/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.5.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/console-link-cronjob/templates/cronjob.yaml
+++ b/stable/console-link-cronjob/templates/cronjob.yaml
@@ -1,4 +1,10 @@
+{{- if .Capabilities.APIVersions.Has "batch/v1/cronjob" -}}
+apiVersion: batch/v1
+{{- else if .Capabilities.APIVersions.Has "batch/v1beta1/cronjob" -}}
 apiVersion: batch/v1beta1
+{{- else -}}
+apiVersion: batch/v1
+{{- end -}}
 kind: CronJob
 metadata:
   name: {{ include "console-link-cronjob.fullname" . }}


### PR DESCRIPTION
- Add logic to use the appropriate version of CronJob api available on the server