### PR TITLE
namespace-rbac-cronjob: v0.2.1

### DIFF
--- a/stable/namespace-rbac-cronjob/Chart.yaml
+++ b/stable/namespace-rbac-cronjob/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/namespace-rbac-cronjob/templates/cronjob.yaml
+++ b/stable/namespace-rbac-cronjob/templates/cronjob.yaml
@@ -1,4 +1,10 @@
+{{- if .Capabilities.APIVersions.Has "batch/v1/cronjob" -}}
+apiVersion: batch/v1
+{{- else if .Capabilities.APIVersions.Has "batch/v1beta1/cronjob" -}}
 apiVersion: batch/v1beta1
+{{- else -}}
+apiVersion: batch/v1
+{{- end -}}
 kind: CronJob
 metadata:
   name: {{ include "console-link-cronjob.fullname" . }}


### PR DESCRIPTION
- Update cronjob api version to fix deprecation error - #457